### PR TITLE
Fix spelling of Uruguay

### DIFF
--- a/content/docs/sign/signpost/_index.md
+++ b/content/docs/sign/signpost/_index.md
@@ -32,4 +32,4 @@
 
 ## South America
 
-- Thick signpost: Urugray, Bolivia
+- Thick signpost: Uruguay, Bolivia

--- a/content/docs/telephone.md
+++ b/content/docs/telephone.md
@@ -41,4 +41,4 @@ weight: 100
 |      |             |     | +51  | Peru      |
 | +250 | Rwanda      |     | +591 | Bolivia   |
 | +254 | Kenya       |     | +593 | Ecuador   |
-| +256 | Uganda      |     | +598 | Urugray   |
+| +256 | Uganda      |     | +598 | Uruguay   |


### PR DESCRIPTION
## Summary
- correct spelling of "Uruguay" in telephone and signpost docs

## Testing
- `grep -n "Urugray" -R content/docs`


------
https://chatgpt.com/codex/tasks/task_e_683fadcbb9548333881f5fd637f4d6c5