### PR TITLE
Fix region spelling

### DIFF
--- a/content/docs/car-meta/_index.md
+++ b/content/docs/car-meta/_index.md
@@ -29,7 +29,7 @@ weight: 400
 
 
 ## Europe Gen 3
-- With antenna: never **North Marcedonia**, **Turkey**
+- With antenna: never **North Macedonia**, **Turkey**
 - Winter: **Czechia, Hungary, Bulgaria**
 - Side mirror with yellow sticker: **Croatia**
 - Before 2019 🇭🇷 🇸🇮 🇷🇴 🇧🇬 🇷🇸 🇲🇰 🇲🇪 🇦🇱:

--- a/content/docs/chevron/_index.md
+++ b/content/docs/chevron/_index.md
@@ -22,7 +22,7 @@ Sweden, <span class="text-rare">Luxembourg</span>
 
 ### Black on White
 
-Serbia, Montenegro, North Marcedonia, Slovenia
+Serbia, Montenegro, North Macedonia, Slovenia
 
 <img src="chevron-rs.png" class="img-md" />
 

--- a/content/docs/language.md
+++ b/content/docs/language.md
@@ -10,7 +10,7 @@ Netherland, Belgium
 **French**  
 France, Belgium, Switzerland  
 **German**  
-Germany, Belgium, Luxemberg, Austria, Switzerland  
+Germany, Belgium, Luxembourg, Austria, Switzerland  
 **Slavic**  
 Poland, Czechia, Slovakia, Yugoslavia (Slovenia, Croatia, Bosnia, Montenegro, Serbia, North Macedonia)  
 **Cyrillic script**  
@@ -171,7 +171,7 @@ The only useful part is to distinguish between Ukraine and Russia
 ### Balkan
 
 - **Serbia**: њ љ џ ј ђ <font color="#aaa">ъ й ё ы э</font>
-- **Marcedonia**: њ љ џ ј ѕ ѓ ќ <font color="#aaa">ъ й ё ы э</font>
+- **Macedonia**: њ љ џ ј ѕ ѓ ќ <font color="#aaa">ъ й ё ы э</font>
 - **Bulgaria**: ѕ <font color="#aaa">й ё ы э</font>
 - **Ukraine**: ґ є і ї <font color="#aaa">ъ й ё ы э</font>
 

--- a/content/docs/sign/traffic-sign/_index.md
+++ b/content/docs/sign/traffic-sign/_index.md
@@ -111,11 +111,11 @@ weight: 10
 
 ### With Belt
 
-Germany, Luxembourg, Hungary, Croatia, Montenegro, North Marcedonia, Portugal, <span class="text-rare">Slovakia</span>
+Germany, Luxembourg, Hungary, Croatia, Montenegro, North Macedonia, Portugal, <span class="text-rare">Slovakia</span>
 
 ### Yellow Background
 
-Finland, Sweden, Iceland, Poland, North Marcedonia, Greece
+Finland, Sweden, Iceland, Poland, North Macedonia, Greece
 
 
 ## Give way
@@ -174,7 +174,7 @@ Finland, Sweden, Iceland, Poland, North Marcedonia, Greece
 
 ### Yellow Background
 
-Finland, Sweden, Iceland,  Poland, North Marcedonia, Greece, Croatia, Slovenia
+Finland, Sweden, Iceland,  Poland, North Macedonia, Greece, Croatia, Slovenia
 
 ## Stop
 


### PR DESCRIPTION
## Summary
- correct the spelling of "Macedonia" and "Luxembourg" in docs

## Testing
- `hugo128 --minify`

------
https://chatgpt.com/codex/tasks/task_e_683fac89668483338f97e4d8916f3a16