### PR TITLE
Add dark theme toggle

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -56,3 +56,23 @@
     margin-top: -$padding-16;
   }
 }
+#theme-toggle {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin-inline-start: $padding-8;
+  cursor: pointer;
+}
+
+#theme-toggle img.book-icon {
+  height: 1.5em;
+  width: 1.5em;
+}
+
+html[data-theme='dark'] {
+  @include theme-dark;
+}
+
+html[data-theme='light'] {
+  @include theme-light;
+}

--- a/assets/theme-toggle.js
+++ b/assets/theme-toggle.js
@@ -1,0 +1,31 @@
+(function () {
+  const storageKey = 'theme';
+  const button = document.getElementById('theme-toggle');
+  const icon = document.getElementById('theme-toggle-icon');
+  const sun = '{{ "svg/sun.svg" | relURL }}';
+  const moon = '{{ "svg/moon.svg" | relURL }}';
+
+  function apply(theme) {
+    if (theme === 'dark') {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      if (icon) icon.src = sun;
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+      if (icon) icon.src = moon;
+      theme = 'light';
+    }
+    localStorage.setItem(storageKey, theme);
+  }
+
+  const saved = localStorage.getItem(storageKey);
+  if (saved) {
+    apply(saved);
+  }
+
+  if (button) {
+    button.addEventListener('click', function () {
+      const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      apply(current);
+    });
+  }
+})();

--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -1,0 +1,18 @@
+<div class="flex align-center justify-between">
+  <label for="menu-control">
+    <img src="{{ "svg/menu.svg" | relURL }}" class="book-icon" alt="Menu" />
+  </label>
+
+  <h3>{{ partial "docs/title" . }}</h3>
+
+  <div class="flex align-center">
+    <label for="toc-control">
+      {{ if default true (default .Site.Params.BookToC .Params.BookToC) }}
+      <img src="{{ "svg/toc.svg" | relURL }}" class="book-icon" alt="Table of Contents" />
+      {{ end }}
+    </label>
+    <button id="theme-toggle" type="button" aria-label="Toggle dark mode">
+      <img id="theme-toggle-icon" src="{{ "svg/moon.svg" | relURL }}" class="book-icon" alt="Toggle theme" />
+    </button>
+  </div>
+</div>

--- a/layouts/partials/docs/inject/footer.html
+++ b/layouts/partials/docs/inject/footer.html
@@ -1,0 +1,2 @@
+{{- $js := resources.Get "theme-toggle.js" | resources.ExecuteAsTemplate "theme-toggle.js" . | resources.Minify | resources.Fingerprint -}}
+<script defer src="{{ $js.RelPermalink }}" {{ template "integrity" $js }}></script>

--- a/static/svg/moon.svg
+++ b/static/svg/moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/>
+</svg>

--- a/static/svg/sun.svg
+++ b/static/svg/sun.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"/>
+</svg>


### PR DESCRIPTION
## Summary
- add moon/sun SVG icons for theme toggle
- create new `theme-toggle.js` to switch between dark/light themes and store preference
- inject toggle script in footer partial
- override default header to include a theme toggle button
- adjust custom SCSS to support dark theme attribute and button styling

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684768268e2c8333857ec6bc73d82342