### PR TITLE
Remove external links from sidebar TOC

### DIFF
--- a/layouts/partials/docs/toc.html
+++ b/layouts/partials/docs/toc.html
@@ -1,0 +1,5 @@
+{{ partial "docs/inject/toc-before" . }}
+{{- $toc := .TableOfContents -}}
+{{- $toc = replaceRE "(?s)<a href=\"https?://[^\"]*\">(.*?)</a>" "$1" $toc -}}
+{{ $toc | safeHTML }}
+{{ partial "docs/inject/toc-after" . }}


### PR DESCRIPTION
## Summary
- override `toc.html` partial
- strip external links from Table of Contents items

## Testing
- `./hugo -D`

------
https://chatgpt.com/codex/tasks/task_e_684d7d93f6508333839ad0f709ce2e0d