### PR TITLE
fix(setup): document local dev setup & split README from site index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,49 @@
 # Geoguessr Note
 
-Write down some metas :)
+Notes for identifying GeoGuessr regions by their *metas* (recurring visual clues).
 
-Unlike other website, we can only search metas by a given country. In this note, the goal is to identify the region based on a given meta.
-
-## Websites
-
-- [Plonk It](https://www.plonkit.net/guide)
-- [Learnable Meta](https://learnablemeta.com/maps)
-- [GeoHints](https://geohints.com/)
+📖 **Read the guide:** <https://dingyiyi0226.github.io/geoguessr-note/>
 
 ## Contribute
 
-All documentation files are located under content/docs. You can
+All documentation files live under `content/docs`. You can
 
-1. Edit directly on GitHub
-2. Edit locally and preview the changes by `hugo server --minify`
+1. Edit directly on GitHub, or
+2. Edit locally and preview your changes (see [Local Development](#local-development) below).
+
+## Local Development
+
+This site is built with [Hugo](https://gohugo.io/) using the [hugo-book](https://github.com/alex-shpak/hugo-book) theme (included as a git submodule).
+
+### Prerequisites
+
+- **Hugo (Extended edition)** — the Extended edition is required because the site processes SCSS.
+  - Windows: `winget install Hugo.Hugo.Extended`
+  - macOS: `brew install hugo`
+  - Others: see the [Hugo install guide](https://gohugo.io/installation/)
+- **Git** (to clone the repo and fetch the theme submodule)
+
+### Setup
+
+1. Clone the repository **with the theme submodule**:
+
+   ```sh
+   git clone --recurse-submodules https://github.com/dingyiyi0226/geoguessr-note.git
+   ```
+
+   If you already cloned without submodules, fetch the theme afterwards:
+
+   ```sh
+   git submodule update --init --recursive
+   ```
+
+2. Start the local dev server:
+
+   ```sh
+   hugo server --minify
+   ```
+
+   Then open <http://localhost:1313/> in your browser. Edits under `content/docs` are reloaded automatically.
+
+> **Note:** If `hugo` is "not recognized" right after installing it, your terminal still holds the old `PATH`;
+> restart your terminal (or IDE, e.g. VS Code) and try again.

--- a/content/_index.md
+++ b/content/_index.md
@@ -18,7 +18,6 @@ Unlike other website, we can only search metas by a given country. In this note,
 
 ## Contribute
 
-All documentation files are located under content/docs. You can
-
-1. Edit directly on GitHub
-2. Edit locally and preview the changes by `hugo server --minify`
+All documentation files are located under `content/docs`.  
+You can edit directly on GitHub, or run the site locally;  
+check the [README](https://github.com/dingyiyi0226/geoguessr-note#geoguessr-note) for setup instructions.


### PR DESCRIPTION
The old README only said `hugo server --minify`, which silently assumes a fully prepared environment. A fresh fork clone actually fails without three undocumented steps. This PR documents them and removes the intro duplicated across README and site.

**README.md** — now developer-facing:

- Adds a **Local Development** section: Hugo **Extended** as prerequisite (required for SCSS), cloning **with the theme submodule** (`--recurse-submodules` / `git submodule update --init --recursive`), and a note that a stale `PATH` needs a terminal/IDE restart after installing Hugo.
- Trimmed to a short description + link to the live guide (no more duplicated content).

**content/_index.md** — now visitor-facing:

- Keeps the meta intro + resource links; `Contribute` points to the README for setup instead of repeating dev instructions on the public landing page.
