### PR TITLE
feat: dark theme toggle

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -60,5 +60,28 @@
 .book-search {
   input {
     border: 0;
-  } 
+  }
+}
+
+// Theme toggle (see assets/js/theme-toggle.js)
+#theme-toggle {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin-inline-start: $padding-8;
+  cursor: pointer;
+}
+
+#theme-toggle img.book-icon {
+  height: 1.5em;
+  width: 1.5em;
+}
+
+// Explicit user choice overrides the system-based base palette (BookTheme = 'auto').
+html[data-theme='dark'] {
+  @include theme-dark;
+}
+
+html[data-theme='light'] {
+  @include theme-light;
 }

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -12,8 +12,9 @@
 
   // System preference, with DEFAULT_THEME as the last resort for 'no-preference'.
   function systemTheme() {
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
-    if (window.matchMedia('(prefers-color-scheme: light)').matches) return 'light';
+    const mm = window.matchMedia;
+    if (mm && mm('(prefers-color-scheme: dark)').matches) return 'dark';
+    if (mm && mm('(prefers-color-scheme: light)').matches) return 'light';
     return DEFAULT_THEME;
   }
 

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -18,13 +18,38 @@
   }
 
   // Priority: attribute already set (pre-paint) > saved choice > system > default.
+  function isTheme(t) {
+    return t === 'dark' || t === 'light';
+  }
+
+  function safeGet(key) {
+    try {
+      return localStorage.getItem(key);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function safeSet(key, value) {
+    try {
+      localStorage.setItem(key, value);
+    } catch (e) {}
+  }
+
   function resolve() {
-    return root.getAttribute('data-theme') || localStorage.getItem(STORAGE_KEY) || systemTheme();
+    const attr = root.getAttribute('data-theme');
+    if (isTheme(attr)) return attr;
+
+    const saved = safeGet(STORAGE_KEY);
+    if (isTheme(saved)) return saved;
+
+    return systemTheme();
   }
 
   function render(theme) {
-    root.setAttribute('data-theme', theme);
-    if (icon) icon.src = theme === 'dark' ? sun : moon;
+    const t = isTheme(theme) ? theme : systemTheme();
+    root.setAttribute('data-theme', t);
+    if (icon) icon.src = t === 'dark' ? sun : moon;
   }
 
   // Reflect the effective theme (e.g. keep the icon in sync) without persisting it,
@@ -35,7 +60,7 @@
     button.addEventListener('click', function () {
       const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
       render(next);
-      localStorage.setItem(STORAGE_KEY, next); // persist only on explicit choice
+      safeSet(STORAGE_KEY, next); // persist only on explicit choice
     });
   }
 })();

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,41 @@
+(function () {
+  const STORAGE_KEY = 'theme';
+  // Fallback theme used only when the visitor's system expresses *no* colour preference.
+  // Safe to change to 'light'.
+  const DEFAULT_THEME = 'dark';
+
+  const sun = '{{ "svg/sun.svg" | relURL }}';
+  const moon = '{{ "svg/moon.svg" | relURL }}';
+  const root = document.documentElement;
+  const button = document.getElementById('theme-toggle');
+  const icon = document.getElementById('theme-toggle-icon');
+
+  // System preference, with DEFAULT_THEME as the last resort for 'no-preference'.
+  function systemTheme() {
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
+    if (window.matchMedia('(prefers-color-scheme: light)').matches) return 'light';
+    return DEFAULT_THEME;
+  }
+
+  // Priority: attribute already set (pre-paint) > saved choice > system > default.
+  function resolve() {
+    return root.getAttribute('data-theme') || localStorage.getItem(STORAGE_KEY) || systemTheme();
+  }
+
+  function render(theme) {
+    root.setAttribute('data-theme', theme);
+    if (icon) icon.src = theme === 'dark' ? sun : moon;
+  }
+
+  // Reflect the effective theme (e.g. keep the icon in sync) without persisting it,
+  // so "follow the system" survives until the user actively chooses.
+  render(resolve());
+
+  if (button) {
+    button.addEventListener('click', function () {
+      const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      render(next);
+      localStorage.setItem(STORAGE_KEY, next); // persist only on explicit choice
+    });
+  }
+})();

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -36,31 +36,52 @@
     } catch (e) {}
   }
 
-  function resolve() {
+  function explicitTheme() {
     const attr = root.getAttribute('data-theme');
     if (isTheme(attr)) return attr;
 
     const saved = safeGet(STORAGE_KEY);
     if (isTheme(saved)) return saved;
 
-    return systemTheme();
+    return null;
   }
 
-  function render(theme) {
+  function syncControls(theme) {
+    const t = isTheme(theme) ? theme : systemTheme();
+    if (icon) icon.src = t === 'dark' ? sun : moon;
+    if (button) button.setAttribute('aria-pressed', t === 'dark' ? 'true' : 'false');
+  }
+
+  function applyExplicit(theme) {
     const t = isTheme(theme) ? theme : systemTheme();
     root.setAttribute('data-theme', t);
-    if (icon) icon.src = t === 'dark' ? sun : moon;
+    syncControls(t);
   }
 
-  // Reflect the effective theme (e.g. keep the icon in sync) without persisting it,
-  // so "follow the system" survives until the user actively chooses.
-  render(resolve());
+  function applySystem() {
+    root.removeAttribute('data-theme'); // keep BookTheme='auto' (CSS) in control
+    syncControls(systemTheme());
+  }
+
+  const explicit = explicitTheme();
+  if (explicit) applyExplicit(explicit);
+  else applySystem();
 
   if (button) {
     button.addEventListener('click', function () {
-      const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-      render(next);
+      const current = root.getAttribute('data-theme') || systemTheme();
+      const next = current === 'dark' ? 'light' : 'dark';
+      applyExplicit(next);
       safeSet(STORAGE_KEY, next); // persist only on explicit choice
     });
   }
-})();
+
+  // If the user hasn't chosen explicitly, keep following system changes.
+  const mq = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
+  if (mq && !explicit) {
+    const onChange = function () {
+      if (!isTheme(safeGet(STORAGE_KEY))) applySystem();
+    };
+    if (mq.addEventListener) mq.addEventListener('change', onChange);
+    else if (mq.addListener) mq.addListener(onChange);
+  }

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -78,12 +78,16 @@
   }
 
   // If the user hasn't chosen explicitly, keep following system changes.
-  const mq = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
-  if (mq && !explicit) {
+  // Listen to both queries: a dark-only listener misses light <-> no-preference
+  // transitions, which never flip the dark query and so never fire.
+  if (window.matchMedia && !explicit) {
     const onChange = function () {
       if (!isTheme(safeGet(STORAGE_KEY))) applySystem();
     };
-    if (mq.addEventListener) mq.addEventListener('change', onChange);
-    else if (mq.addListener) mq.addListener(onChange);
+    ['(prefers-color-scheme: dark)', '(prefers-color-scheme: light)'].forEach(function (q) {
+      const mq = window.matchMedia(q);
+      if (mq.addEventListener) mq.addEventListener('change', onChange);
+      else if (mq.addListener) mq.addListener(onChange);
+    });
   }
 })();

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -85,3 +85,4 @@
     if (mq.addEventListener) mq.addEventListener('change', onChange);
     else if (mq.addListener) mq.addListener(onChange);
   }
+})();

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -9,7 +9,7 @@ enableGitInfo = true
   name = "Github"
   url = "https://github.com/dingyiyi0226/geoguessr-note"
 [params]
-  BookTheme = 'light'
+  BookTheme = 'auto'
   BookRepo = 'https://github.com/dingyiyi0226/geoguessr-note'
   BookLastChangeLink = 'https://github.com/dingyiyi0226/geoguessr-note/commit/{{ .GitInfo.Hash }}'
   BookEditLink = 'https://github.com/dingyiyi0226/geoguessr-note/edit/master/{{ .Path }}'

--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -1,0 +1,20 @@
+{{- /* Overrides the theme header (themes/hugo-book/layouts/_partials/docs/header.html)
+       to add the theme toggle. Re-sync with the theme partial on hugo-book bumps. */ -}}
+<div class="flex align-center justify-between">
+  <label for="menu-control">
+    <img src="{{ partial "docs/icon" "menu" }}" class="book-icon" alt="{{ partial "docs/text/i18n" "Menu" }}" />
+  </label>
+
+  <h3>{{ partial "docs/title" . }}</h3>
+
+  <div class="flex align-center">
+    <label for="toc-control">
+      {{ if partial "docs/toc-show" . }}
+      <img src="{{ partial "docs/icon" "toc" }}" class="book-icon" alt="{{ partial "docs/text/i18n" "Table of Contents" }}" />
+      {{ end }}
+    </label>
+    <button id="theme-toggle" type="button" aria-label="Toggle theme">
+      <img id="theme-toggle-icon" src="{{ "svg/moon.svg" | relURL }}" class="book-icon" alt="Toggle theme" />
+    </button>
+  </div>
+</div>

--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -14,7 +14,7 @@
       {{ end }}
     </label>
     <button id="theme-toggle" type="button" aria-label="Toggle theme">
-      <img id="theme-toggle-icon" src="{{ "svg/moon.svg" | relURL }}" class="book-icon" alt="Toggle theme" />
+      <img id="theme-toggle-icon" src="{{ "svg/moon.svg" | relURL }}" class="book-icon" alt="" aria-hidden="true" />
     </button>
   </div>
 </div>

--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -13,6 +13,8 @@
       <img src="{{ partial "docs/icon" "toc" }}" class="book-icon" alt="{{ partial "docs/text/i18n" "Table of Contents" }}" />
       {{ end }}
     </label>
+    {{- /* The toggle needs JS to work, so hide it for no-JS visitors. */ -}}
+    <noscript><style>#theme-toggle { display: none; }</style></noscript>
     <button id="theme-toggle" type="button" aria-label="Toggle theme">
       <img id="theme-toggle-icon" src="{{ "svg/moon.svg" | relURL }}" class="book-icon" alt="" aria-hidden="true" />
     </button>

--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -15,7 +15,7 @@
     </label>
     {{- /* The toggle needs JS to work, so hide it for no-JS visitors. */ -}}
     <noscript><style>#theme-toggle { display: none; }</style></noscript>
-    <button id="theme-toggle" type="button" aria-label="Toggle theme">
+    <button id="theme-toggle" type="button" aria-label="{{ partial "docs/text/i18n" "Toggle theme" }}">
       <img id="theme-toggle-icon" src="{{ "svg/moon.svg" | relURL }}" class="book-icon" alt="" aria-hidden="true" />
     </button>
   </div>

--- a/layouts/partials/docs/inject/footer.html
+++ b/layouts/partials/docs/inject/footer.html
@@ -1,0 +1,2 @@
+{{- $js := resources.Get "js/theme-toggle.js" | resources.ExecuteAsTemplate "js/theme-toggle.js" . | resources.Minify | resources.Fingerprint -}}
+<script defer src="{{ $js.RelPermalink }}" {{ template "integrity" $js }}></script>

--- a/layouts/partials/docs/inject/head.html
+++ b/layouts/partials/docs/inject/head.html
@@ -4,7 +4,7 @@
   (function () {
     try {
       var t = localStorage.getItem('theme');
-      if (t) document.documentElement.setAttribute('data-theme', t);
+      if (t === 'dark' || t === 'light') document.documentElement.setAttribute('data-theme', t);
     } catch (e) {}
   })();
 </script>

--- a/layouts/partials/docs/inject/head.html
+++ b/layouts/partials/docs/inject/head.html
@@ -1,0 +1,10 @@
+{{- /* Pre-paint: apply an explicit saved theme before first render to avoid a flash.
+       The system-preference case needs no JS here — BookTheme='auto' handles it in CSS. */ -}}
+<script>
+  (function () {
+    try {
+      var t = localStorage.getItem('theme');
+      if (t) document.documentElement.setAttribute('data-theme', t);
+    } catch (e) {}
+  })();
+</script>

--- a/static/svg/moon.svg
+++ b/static/svg/moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/>
+</svg>

--- a/static/svg/sun.svg
+++ b/static/svg/sun.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"/>
+</svg>


### PR DESCRIPTION
Adds a light/dark **theme toggle** to the site header, superseding the stale draft "Add dark theme toggle".

## What

- A toggle button in the header switches between light and dark.
- Colours reuse hugo-book's built-in `theme-light` / `theme-dark` palettes — no hand-picked colours, so the site stays consistent with the theme.

## How the theme is chosen

On each visit the theme is resolved in this order:

1. A previously toggled choice (`localStorage`).
2. Otherwise the system preference (`prefers-color-scheme`).
3. Otherwise (system states *no* preference) a configurable default.

The system preference is only *followed* until the visitor explicitly toggles; the chosen theme is persisted **only on click**, so "follow my system" keeps working until you actively pick one.

The default for case 3 lives as a single const at the top of `assets/js/theme-toggle.js`:

```js
const DEFAULT_THEME = 'dark'; // change to 'light' if preferred
```

It is currently `'dark'` and can be changed freely by the maintainer in case they disagree with my personal preference :3

## Notes

- `BookTheme` is set to `'auto'`, so visitors **without JavaScript** still get the system palette.
- A tiny pre-paint script in `<head>` applies a saved choice before first render to avoid a flash of the wrong theme.
- The header override is rebased on the **current** hugo-book header partial (keeps the theme's i18n and icon partials intact); it needs a re-sync on future theme bumps.
- A second toggle in the footer for long articles is intentionally out of scope and left as a possible follow-up.
