### PR TITLE
Telephone: world map, full country-code list & area-code maps

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -55,6 +55,12 @@
   blockquote details summary:first-child {
     margin-top: -$padding-16;
   }
+
+  // Nested <details>: theme's descendant selector rotates inner markers too;
+  // keep a collapsed nested block's caret pointing right.
+  details:not([open]) > summary::before {
+    transform: none;
+  }
 }
 
 .book-search {

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -56,10 +56,14 @@
     margin-top: -$padding-16;
   }
 
-  // Nested <details>: theme's descendant selector rotates inner markers too;
-  // keep a collapsed nested block's caret pointing right.
-  details:not([open]) > summary::before {
-    transform: none;
+  // Nested <details>: theme's descendant `details[open] summary` rules leak
+  // into a collapsed nested block (rotated caret + lost negative margin = extra gap).
+  details:not([open]) > summary {
+    margin-bottom: -$padding-16;
+
+    &::before {
+      transform: none;
+    }
   }
 }
 

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -56,9 +56,9 @@
     margin-top: -$padding-16;
   }
 
-  // Nested <details>: theme's descendant `details[open] summary` rules leak
-  // into a collapsed nested block (rotated caret + lost negative margin = extra gap).
-  details:not([open]) > summary {
+  // Nested <details>: theme's descendant `details[open] summary` rules leak into a
+  // collapsed nested block (rotated caret + lost negative margin). Scope to that case.
+  details[open] details:not([open]) > summary {
     margin-bottom: -$padding-16;
 
     &::before {

--- a/content/docs/telephone.md
+++ b/content/docs/telephone.md
@@ -232,7 +232,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://learnablemeta.com/images/1398/1749471291095-UdG.avif"/>
+<img src="https://learnablemeta.com/images/1398/1749471291095-UdG.avif" alt="Argentina telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -240,7 +240,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/australia/Phone_codes.png"/>
+<img src="https://www.plonkit.net/images/australia/Phone_codes.png" alt="Australia telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -248,7 +248,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://upload.wikimedia.org/wikipedia/commons/7/7b/Telefonvorwahlbereiche-Oesterreich.svg"/>
+<img src="https://upload.wikimedia.org/wikipedia/commons/7/7b/Telefonvorwahlbereiche-Oesterreich.svg" alt="Austria telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -261,7 +261,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://images.squarespace-cdn.com/content/v1/60f6054f4e76b03092956de8/930c8141-7d6e-4397-a56c-f58b902e85c1/Brasil_-_Códigos_de_área_DDD.png"/>
+<img src="https://images.squarespace-cdn.com/content/v1/60f6054f4e76b03092956de8/930c8141-7d6e-4397-a56c-f58b902e85c1/Brasil_-_Códigos_de_área_DDD.png" alt="Brazil telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -269,7 +269,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/bulgaria/bg_areacodes.png"/>
+<img src="https://www.plonkit.net/images/bulgaria/bg_areacodes.png" alt="Bulgaria telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -277,7 +277,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/chile/Chile_Area_Codes.png"/>
+<img src="https://www.plonkit.net/images/chile/Chile_Area_Codes.png" alt="Chile telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -285,7 +285,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/croatia/hr_areacodes_copy.png"/>
+<img src="https://www.plonkit.net/images/croatia/hr_areacodes_copy.png" alt="Croatia telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -293,7 +293,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/czechia/cz_areacodes.png"/>
+<img src="https://www.plonkit.net/images/czechia/cz_areacodes.png" alt="Czech Republic telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -301,7 +301,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/france/2_areacodes.png"/>
+<img src="https://www.plonkit.net/images/france/2_areacodes.png" alt="France telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -309,7 +309,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/germany/800px-Karte_Telefonvorwahlen_Deutschland.png"/>
+<img src="https://www.plonkit.net/images/germany/800px-Karte_Telefonvorwahlen_Deutschland.png" alt="Germany telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -317,7 +317,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://upload.wikimedia.org/wikipedia/commons/9/92/Ghana_regional_phone_codes.jpg"/>
+<img src="https://upload.wikimedia.org/wikipedia/commons/9/92/Ghana_regional_phone_codes.jpg" alt="Ghana telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -325,7 +325,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/greece/gr_areacodes_darkmode.png"/>
+<img src="https://www.plonkit.net/images/greece/gr_areacodes_darkmode.png" alt="Greece telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -333,7 +333,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/italy/it_phonecodes.png"/>
+<img src="https://www.plonkit.net/images/italy/it_phonecodes.png" alt="Italy telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -346,7 +346,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://images.squarespace-cdn.com/content/v1/60f6054f4e76b03092956de8/19dfb5b1-0cb0-49a5-adb4-9b211585bffc/19.png"/>
+<img src="https://images.squarespace-cdn.com/content/v1/60f6054f4e76b03092956de8/19dfb5b1-0cb0-49a5-adb4-9b211585bffc/19.png" alt="Japan telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -354,7 +354,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/mexico/mx_areacodes_nobg.png"/>
+<img src="https://www.plonkit.net/images/mexico/mx_areacodes_nobg.png" alt="Mexico telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -362,7 +362,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/namibia/12.png"/>
+<img src="https://www.plonkit.net/images/namibia/12.png" alt="Namibia telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -370,7 +370,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/netherlands/Area_codes_of_the_Netherlands.png"/>
+<img src="https://www.plonkit.net/images/netherlands/Area_codes_of_the_Netherlands.png" alt="Netherlands telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -378,7 +378,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/new-zealand/nz_area_codes_new.png"/>
+<img src="https://www.plonkit.net/images/new-zealand/nz_area_codes_new.png" alt="New Zealand telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -386,7 +386,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/panama/13.png"/>
+<img src="https://www.plonkit.net/images/panama/13.png" alt="Panama telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -394,7 +394,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/poland/Poland-area-codes.png"/>
+<img src="https://www.plonkit.net/images/poland/Poland-area-codes.png" alt="Poland telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -402,7 +402,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/portugal/2areacodes_darkmode.webp"/>
+<img src="https://www.plonkit.net/images/portugal/2areacodes_darkmode.webp" alt="Portugal telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -410,7 +410,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/russia/areacodes.png"/>
+<img src="https://www.plonkit.net/images/russia/areacodes.png" alt="Russia telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -418,7 +418,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/slovakia/sk_areacodes.png"/>
+<img src="https://www.plonkit.net/images/slovakia/sk_areacodes.png" alt="Slovakia telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -426,7 +426,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/south-africa/ZA_Phone_Code_Map.png"/>
+<img src="https://www.plonkit.net/images/south-africa/ZA_Phone_Code_Map.png" alt="South Africa telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -434,7 +434,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/south-korea/kr_phonecodes.png"/>
+<img src="https://www.plonkit.net/images/south-korea/kr_phonecodes.png" alt="South Korea telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -442,7 +442,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/spain/Spain-telephone-codes__281_29_darkmode.png"/>
+<img src="https://www.plonkit.net/images/spain/Spain-telephone-codes__281_29_darkmode.png" alt="Spain telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -450,7 +450,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/sri-lanka/Sri_area_codes.png"/>
+<img src="https://www.plonkit.net/images/sri-lanka/Sri_area_codes.png" alt="Sri Lanka telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -458,7 +458,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/sweden/Phone_numbers.png"/>
+<img src="https://www.plonkit.net/images/sweden/Phone_numbers.png" alt="Sweden telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -466,7 +466,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/taiwan/a-more-detailed-taiwan-area-code-map.webp"/>
+<img src="https://www.plonkit.net/images/taiwan/a-more-detailed-taiwan-area-code-map.webp" alt="Taiwan telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -474,7 +474,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/thailand/Indicatifs_Thailande.png"/>
+<img src="https://www.plonkit.net/images/thailand/Indicatifs_Thailande.png" alt="Thailand telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -482,7 +482,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/turkey/tr_areacodes_nobg.png"/>
+<img src="https://www.plonkit.net/images/turkey/tr_areacodes_nobg.png" alt="Turkey telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -490,7 +490,7 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/united-states/US_area_codes_map.jfif"/>
+<img src="https://www.plonkit.net/images/united-states/US_area_codes_map.jfif" alt="United States telephone area code map" loading="lazy"/>
 
 {{% /details %}}
 
@@ -498,6 +498,6 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% details "Full" %}}
 
-<img src="https://www.plonkit.net/images/vietnam/vnareacodes_map.jpg"/>
+<img src="https://www.plonkit.net/images/vietnam/vnareacodes_map.jpg" alt="Vietnam telephone area code map" loading="lazy"/>
 
 {{% /details %}}

--- a/content/docs/telephone.md
+++ b/content/docs/telephone.md
@@ -28,7 +28,37 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 | +1 | United States ([area codes](#united-states)) |
 | +1 | Canada |
 
-> `+1` is shared by ~25 North American Numbering Plan members (mostly Caribbean territories), each distinguished by its 3-digit area code.
+`+1` is shared by ~25 North American Numbering Plan members, each distinguished by its 3-digit area code:
+
+{{% details "Other NANP members (Caribbean & Pacific)" %}}
+
+| Area code | Country / territory |
+|:-|:-|
+| +1 242 | Bahamas |
+| +1 246 | Barbados |
+| +1 264 | Anguilla |
+| +1 268 | Antigua and Barbuda |
+| +1 284 | British Virgin Islands |
+| +1 340 | U.S. Virgin Islands |
+| +1 345 | Cayman Islands |
+| +1 441 | Bermuda |
+| +1 473 | Grenada |
+| +1 649 | Turks and Caicos Islands |
+| +1 658 / 876 | Jamaica |
+| +1 664 | Montserrat |
+| +1 670 | Northern Mariana Islands |
+| +1 671 | Guam |
+| +1 684 | American Samoa |
+| +1 721 | Sint Maarten |
+| +1 758 | Saint Lucia |
+| +1 767 | Dominica |
+| +1 784 | Saint Vincent and the Grenadines |
+| +1 787 / 939 | Puerto Rico |
+| +1 809 / 829 / 849 | Dominican Republic |
+| +1 868 | Trinidad and Tobago |
+| +1 869 | Saint Kitts and Nevis |
+
+{{% /details %}}
 
 **Zone 2 — Africa (and nearby territories)**
 

--- a/content/docs/telephone.md
+++ b/content/docs/telephone.md
@@ -17,6 +17,178 @@ First identify the code, then narrow down further by area code (see below; limit
   </figcaption>
 </figure>
 
+Prefer a **lookup table**? The list below covers every country's calling code, grouped by [ITU-T E.164](https://en.wikipedia.org/wiki/List_of_country_calling_codes) zone:
+
+{{% details "All country calling codes" %}}
+
+**Zone 1 — North America (NANP)**
+
+| Code | Country       |
+|:-----|:--------------|
+| +1   | United States |
+| +1   | Canada        |
+
+> `+1` is shared by ~25 North American Numbering Plan members (mostly Caribbean territories), each distinguished by its 3-digit area code.
+
+**Zone 2 — Africa (and nearby territories)**
+
+| Code | Country                  |   | Code | Country           |
+|:-----|:-------------------------|:-:|:-----|:------------------|
+| +20  | Egypt                    |   | +251 | Ethiopia          |
+| +211 | South Sudan              |   | +252 | Somalia           |
+| +212 | Morocco                  |   | +253 | Djibouti          |
+| +213 | Algeria                  |   | +254 | Kenya             |
+| +216 | Tunisia                  |   | +255 | Tanzania          |
+| +218 | Libya                    |   | +256 | Uganda            |
+| +220 | Gambia                   |   | +257 | Burundi           |
+| +221 | Senegal                  |   | +258 | Mozambique        |
+| +222 | Mauritania               |   | +260 | Zambia            |
+| +223 | Mali                     |   | +261 | Madagascar        |
+| +224 | Guinea                   |   | +262 | Réunion & Mayotte |
+| +225 | Côte d'Ivoire            |   | +263 | Zimbabwe          |
+| +226 | Burkina Faso             |   | +264 | Namibia           |
+| +227 | Niger                    |   | +265 | Malawi            |
+| +228 | Togo                     |   | +266 | Lesotho           |
+| +229 | Benin                    |   | +267 | Botswana          |
+| +230 | Mauritius                |   | +268 | Eswatini          |
+| +231 | Liberia                  |   | +269 | Comoros           |
+| +232 | Sierra Leone             |   | +27  | South Africa      |
+| +233 | Ghana                    |   | +290 | Saint Helena      |
+| +234 | Nigeria                  |   | +291 | Eritrea           |
+| +235 | Chad                     |   | +297 | Aruba             |
+| +236 | Central African Republic |   | +298 | Faroe Islands     |
+| +237 | Cameroon                 |   | +299 | Greenland         |
+| +238 | Cape Verde               |   |      |                   |
+| +239 | São Tomé and Príncipe    |   |      |                   |
+| +240 | Equatorial Guinea        |   |      |                   |
+| +241 | Gabon                    |   |      |                   |
+| +242 | Republic of the Congo    |   |      |                   |
+| +243 | DR Congo                 |   |      |                   |
+| +244 | Angola                   |   |      |                   |
+| +245 | Guinea-Bissau            |   |      |                   |
+| +246 | Diego Garcia (BIOT)      |   |      |                   |
+| +247 | Ascension Island         |   |      |                   |
+| +248 | Seychelles               |   |      |                   |
+| +249 | Sudan                    |   |      |                   |
+| +250 | Rwanda                   |   |      |                   |
+
+**Zone 3 & 4 — Europe**
+
+| Code | Country     |   | Code | Country                |
+|:-----|:------------|:-:|:-----|:-----------------------|
+| +30  | Greece      |   | +377 | Monaco                 |
+| +31  | Netherlands |   | +378 | San Marino             |
+| +32  | Belgium     |   | +379 | Vatican City           |
+| +33  | France      |   | +380 | Ukraine                |
+| +34  | Spain       |   | +381 | Serbia                 |
+| +350 | Gibraltar   |   | +382 | Montenegro             |
+| +351 | Portugal    |   | +383 | Kosovo                 |
+| +352 | Luxembourg  |   | +385 | Croatia                |
+| +353 | Ireland     |   | +386 | Slovenia               |
+| +354 | Iceland     |   | +387 | Bosnia and Herzegovina |
+| +355 | Albania     |   | +389 | North Macedonia        |
+| +356 | Malta       |   | +39  | Italy                  |
+| +357 | Cyprus      |   | +40  | Romania                |
+| +358 | Finland     |   | +41  | Switzerland            |
+| +359 | Bulgaria    |   | +420 | Czech Republic         |
+| +36  | Hungary     |   | +421 | Slovakia               |
+| +370 | Lithuania   |   | +423 | Liechtenstein          |
+| +371 | Latvia      |   | +43  | Austria                |
+| +372 | Estonia     |   | +44  | United Kingdom         |
+| +373 | Moldova     |   | +45  | Denmark                |
+| +374 | Armenia     |   | +46  | Sweden                 |
+| +375 | Belarus     |   | +47  | Norway                 |
+| +376 | Andorra     |   | +48  | Poland                 |
+|      |             |   | +49  | Germany                |
+
+**Zone 5 — Central & South America**
+
+| Code | Country                   |   | Code | Country                              |
+|:-----|:--------------------------|:-:|:-----|:-------------------------------------|
+| +500 | Falkland Islands          |   | +56  | Chile                                |
+| +501 | Belize                    |   | +57  | Colombia                             |
+| +502 | Guatemala                 |   | +58  | Venezuela                            |
+| +503 | El Salvador               |   | +590 | Guadeloupe, St Barthélemy, St Martin |
+| +504 | Honduras                  |   | +591 | Bolivia                              |
+| +505 | Nicaragua                 |   | +592 | Guyana                               |
+| +506 | Costa Rica                |   | +593 | Ecuador                              |
+| +507 | Panama                    |   | +594 | French Guiana                        |
+| +508 | Saint Pierre and Miquelon |   | +595 | Paraguay                             |
+| +509 | Haiti                     |   | +596 | Martinique                           |
+| +51  | Peru                      |   | +597 | Suriname                             |
+| +52  | Mexico                    |   | +598 | Uruguay                              |
+| +53  | Cuba                      |   | +599 | Curaçao & Caribbean Netherlands      |
+| +54  | Argentina                 |   |      |                                      |
+| +55  | Brazil                    |   |      |                                      |
+
+**Zone 6 — Southeast Asia & Oceania**
+
+| Code | Country          |   | Code | Country           |
+|:-----|:-----------------|:-:|:-----|:------------------|
+| +60  | Malaysia         |   | +681 | Wallis and Futuna |
+| +61  | Australia        |   | +682 | Cook Islands      |
+| +62  | Indonesia        |   | +683 | Niue              |
+| +63  | Philippines      |   | +685 | Samoa             |
+| +64  | New Zealand      |   | +686 | Kiribati          |
+| +65  | Singapore        |   | +687 | New Caledonia     |
+| +66  | Thailand         |   | +688 | Tuvalu            |
+| +670 | Timor-Leste      |   | +689 | French Polynesia  |
+| +672 | Norfolk Island   |   | +690 | Tokelau           |
+| +673 | Brunei           |   | +691 | Micronesia        |
+| +674 | Nauru            |   | +692 | Marshall Islands  |
+| +675 | Papua New Guinea |   |      |                   |
+| +676 | Tonga            |   |      |                   |
+| +677 | Solomon Islands  |   |      |                   |
+| +678 | Vanuatu          |   |      |                   |
+| +679 | Fiji             |   |      |                   |
+| +680 | Palau            |   |      |                   |
+
+**Zone 7 — Russia & Kazakhstan**
+
+| Code | Country    |
+|:-----|:-----------|
+| +7   | Russia     |
+| +7   | Kazakhstan |
+
+**Zone 8 — East Asia & special services**
+
+| Code | Country     |
+|:-----|:------------|
+| +81  | Japan       |
+| +82  | South Korea |
+| +84  | Vietnam     |
+| +850 | North Korea |
+| +852 | Hong Kong   |
+| +853 | Macau       |
+| +855 | Cambodia    |
+| +856 | Laos        |
+| +86  | China       |
+| +880 | Bangladesh  |
+| +886 | Taiwan      |
+
+**Zone 9 — West, Central & South Asia**
+
+| Code | Country      |   | Code | Country              |
+|:-----|:-------------|:-:|:-----|:---------------------|
+| +90  | Turkey       |   | +971 | United Arab Emirates |
+| +91  | India        |   | +972 | Israel               |
+| +92  | Pakistan     |   | +973 | Bahrain              |
+| +93  | Afghanistan  |   | +974 | Qatar                |
+| +94  | Sri Lanka    |   | +975 | Bhutan               |
+| +95  | Myanmar      |   | +976 | Mongolia             |
+| +960 | Maldives     |   | +977 | Nepal                |
+| +961 | Lebanon      |   | +98  | Iran                 |
+| +962 | Jordan       |   | +992 | Tajikistan           |
+| +963 | Syria        |   | +993 | Turkmenistan         |
+| +964 | Iraq         |   | +994 | Azerbaijan           |
+| +965 | Kuwait       |   | +995 | Georgia              |
+| +966 | Saudi Arabia |   | +996 | Kyrgyzstan           |
+| +967 | Yemen        |   | +998 | Uzbekistan           |
+| +968 | Oman         |   |      |                      |
+| +970 | Palestine    |   |      |                      |
+
+{{% /details %}}
+
 ## Area code
 
 ### Japan
@@ -44,14 +216,3 @@ First identify the code, then narrow down further by area code (see below; limit
 <img src="https://images.squarespace-cdn.com/content/v1/60f6054f4e76b03092956de8/930c8141-7d6e-4397-a56c-f58b902e85c1/Brasil_-_Códigos_de_área_DDD.png"/>
 
 {{% /details %}}
-
-## Country code
-
-| Code | Country     |     | Code | Country   |
-|:---- |:----------- | --- |:---- |:--------- |
-| +61  | Australia   |     | +54  | Argentina |
-| +64  | New Zealand |     | +56  | Chile     |
-|      |             |     | +51  | Peru      |
-| +250 | Rwanda      |     | +591 | Bolivia   |
-| +254 | Kenya       |     | +593 | Ecuador   |
-| +256 | Uganda      |     | +598 | Uruguay   |

--- a/content/docs/telephone.md
+++ b/content/docs/telephone.md
@@ -4,9 +4,9 @@ weight: 100
 
 # Telephone
 
-Every country is reachable by an international **country calling code** (`+XX`).  
+Every country is reachable by an international **country calling code** (`+X…`).  
 This world map is the quickest first anchor:  
-First identify the code, then narrow down further by area code (see below; limited to countries that use one)
+First identify the code, then narrow down further by area code (see below; limited to countries that use one).
 
 <figure>
   <img src="https://upload.wikimedia.org/wikipedia/commons/5/55/Country_calling_codes_map.svg" alt="World map of international country calling codes" loading="lazy" style="width: 100%;" />

--- a/content/docs/telephone.md
+++ b/content/docs/telephone.md
@@ -17,179 +17,240 @@ First identify the code, then narrow down further by area code (see below; limit
   </figcaption>
 </figure>
 
-Prefer a **lookup table**? The list below covers every country's calling code, grouped by [ITU-T E.164](https://en.wikipedia.org/wiki/List_of_country_calling_codes) zone:
+Prefer a **lookup table**? The list below covers every country's calling code, grouped by [ITU-T E.164](https://en.wikipedia.org/wiki/List_of_country_calling_codes) zone. Countries with a regional breakdown link to their [area codes](#area-codes):
 
 {{% details "All country calling codes" %}}
 
 **Zone 1 — North America (NANP)**
 
-| Code | Country       |
-|:-----|:--------------|
-| +1   | United States |
-| +1   | Canada        |
+| Code | Country |
+|:-|:-|
+| +1 | United States ([area codes](#united-states)) |
+| +1 | Canada |
 
 > `+1` is shared by ~25 North American Numbering Plan members (mostly Caribbean territories), each distinguished by its 3-digit area code.
 
 **Zone 2 — Africa (and nearby territories)**
 
-| Code | Country                  |   | Code | Country           |
-|:-----|:-------------------------|:-:|:-----|:------------------|
-| +20  | Egypt                    |   | +251 | Ethiopia          |
-| +211 | South Sudan              |   | +252 | Somalia           |
-| +212 | Morocco                  |   | +253 | Djibouti          |
-| +213 | Algeria                  |   | +254 | Kenya             |
-| +216 | Tunisia                  |   | +255 | Tanzania          |
-| +218 | Libya                    |   | +256 | Uganda            |
-| +220 | Gambia                   |   | +257 | Burundi           |
-| +221 | Senegal                  |   | +258 | Mozambique        |
-| +222 | Mauritania               |   | +260 | Zambia            |
-| +223 | Mali                     |   | +261 | Madagascar        |
-| +224 | Guinea                   |   | +262 | Réunion & Mayotte |
-| +225 | Côte d'Ivoire            |   | +263 | Zimbabwe          |
-| +226 | Burkina Faso             |   | +264 | Namibia           |
-| +227 | Niger                    |   | +265 | Malawi            |
-| +228 | Togo                     |   | +266 | Lesotho           |
-| +229 | Benin                    |   | +267 | Botswana          |
-| +230 | Mauritius                |   | +268 | Eswatini          |
-| +231 | Liberia                  |   | +269 | Comoros           |
-| +232 | Sierra Leone             |   | +27  | South Africa      |
-| +233 | Ghana                    |   | +290 | Saint Helena      |
-| +234 | Nigeria                  |   | +291 | Eritrea           |
-| +235 | Chad                     |   | +297 | Aruba             |
-| +236 | Central African Republic |   | +298 | Faroe Islands     |
-| +237 | Cameroon                 |   | +299 | Greenland         |
-| +238 | Cape Verde               |   |      |                   |
-| +239 | São Tomé and Príncipe    |   |      |                   |
-| +240 | Equatorial Guinea        |   |      |                   |
-| +241 | Gabon                    |   |      |                   |
-| +242 | Republic of the Congo    |   |      |                   |
-| +243 | DR Congo                 |   |      |                   |
-| +244 | Angola                   |   |      |                   |
-| +245 | Guinea-Bissau            |   |      |                   |
-| +246 | Diego Garcia (BIOT)      |   |      |                   |
-| +247 | Ascension Island         |   |      |                   |
-| +248 | Seychelles               |   |      |                   |
-| +249 | Sudan                    |   |      |                   |
-| +250 | Rwanda                   |   |      |                   |
+| Code | Country | | Code | Country |
+|:-|:-|:-:|:-|:-|
+| +20 | Egypt | | +251 | Ethiopia |
+| +211 | South Sudan | | +252 | Somalia |
+| +212 | Morocco | | +253 | Djibouti |
+| +213 | Algeria | | +254 | Kenya |
+| +216 | Tunisia | | +255 | Tanzania |
+| +218 | Libya | | +256 | Uganda |
+| +220 | Gambia | | +257 | Burundi |
+| +221 | Senegal | | +258 | Mozambique |
+| +222 | Mauritania | | +260 | Zambia |
+| +223 | Mali | | +261 | Madagascar |
+| +224 | Guinea | | +262 | Réunion & Mayotte |
+| +225 | Côte d'Ivoire | | +263 | Zimbabwe |
+| +226 | Burkina Faso | | +264 | Namibia ([area codes](#namibia)) |
+| +227 | Niger | | +265 | Malawi |
+| +228 | Togo | | +266 | Lesotho |
+| +229 | Benin | | +267 | Botswana |
+| +230 | Mauritius | | +268 | Eswatini |
+| +231 | Liberia | | +269 | Comoros |
+| +232 | Sierra Leone | | +27 | South Africa ([area codes](#south-africa)) |
+| +233 | Ghana ([area codes](#ghana)) | | +290 | Saint Helena |
+| +234 | Nigeria | | +291 | Eritrea |
+| +235 | Chad | | +297 | Aruba |
+| +236 | Central African Republic | | +298 | Faroe Islands |
+| +237 | Cameroon | | +299 | Greenland |
+| +238 | Cape Verde | | | |
+| +239 | São Tomé and Príncipe | | | |
+| +240 | Equatorial Guinea | | | |
+| +241 | Gabon | | | |
+| +242 | Republic of the Congo | | | |
+| +243 | DR Congo | | | |
+| +244 | Angola | | | |
+| +245 | Guinea-Bissau | | | |
+| +246 | Diego Garcia (BIOT) | | | |
+| +247 | Ascension Island | | | |
+| +248 | Seychelles | | | |
+| +249 | Sudan | | | |
+| +250 | Rwanda | | | |
 
 **Zone 3 & 4 — Europe**
 
-| Code | Country     |   | Code | Country                |
-|:-----|:------------|:-:|:-----|:-----------------------|
-| +30  | Greece      |   | +377 | Monaco                 |
-| +31  | Netherlands |   | +378 | San Marino             |
-| +32  | Belgium     |   | +379 | Vatican City           |
-| +33  | France      |   | +380 | Ukraine                |
-| +34  | Spain       |   | +381 | Serbia                 |
-| +350 | Gibraltar   |   | +382 | Montenegro             |
-| +351 | Portugal    |   | +383 | Kosovo                 |
-| +352 | Luxembourg  |   | +385 | Croatia                |
-| +353 | Ireland     |   | +386 | Slovenia               |
-| +354 | Iceland     |   | +387 | Bosnia and Herzegovina |
-| +355 | Albania     |   | +389 | North Macedonia        |
-| +356 | Malta       |   | +39  | Italy                  |
-| +357 | Cyprus      |   | +40  | Romania                |
-| +358 | Finland     |   | +41  | Switzerland            |
-| +359 | Bulgaria    |   | +420 | Czech Republic         |
-| +36  | Hungary     |   | +421 | Slovakia               |
-| +370 | Lithuania   |   | +423 | Liechtenstein          |
-| +371 | Latvia      |   | +43  | Austria                |
-| +372 | Estonia     |   | +44  | United Kingdom         |
-| +373 | Moldova     |   | +45  | Denmark                |
-| +374 | Armenia     |   | +46  | Sweden                 |
-| +375 | Belarus     |   | +47  | Norway                 |
-| +376 | Andorra     |   | +48  | Poland                 |
-|      |             |   | +49  | Germany                |
+| Code | Country | | Code | Country |
+|:-|:-|:-:|:-|:-|
+| +30 | Greece ([area codes](#greece)) | | +377 | Monaco |
+| +31 | Netherlands ([area codes](#netherlands)) | | +378 | San Marino |
+| +32 | Belgium | | +379 | Vatican City |
+| +33 | France ([area codes](#france)) | | +380 | Ukraine |
+| +34 | Spain ([area codes](#spain)) | | +381 | Serbia |
+| +350 | Gibraltar | | +382 | Montenegro |
+| +351 | Portugal ([area codes](#portugal)) | | +383 | Kosovo |
+| +352 | Luxembourg | | +385 | Croatia ([area codes](#croatia)) |
+| +353 | Ireland | | +386 | Slovenia |
+| +354 | Iceland | | +387 | Bosnia and Herzegovina |
+| +355 | Albania | | +389 | North Macedonia |
+| +356 | Malta | | +39 | Italy ([area codes](#italy)) |
+| +357 | Cyprus | | +40 | Romania |
+| +358 | Finland | | +41 | Switzerland |
+| +359 | Bulgaria ([area codes](#bulgaria)) | | +420 | Czech Republic ([area codes](#czech-republic)) |
+| +36 | Hungary | | +421 | Slovakia ([area codes](#slovakia)) |
+| +370 | Lithuania | | +423 | Liechtenstein |
+| +371 | Latvia | | +43 | Austria ([area codes](#austria)) |
+| +372 | Estonia | | +44 | United Kingdom |
+| +373 | Moldova | | +45 | Denmark |
+| +374 | Armenia | | +46 | Sweden ([area codes](#sweden)) |
+| +375 | Belarus | | +47 | Norway |
+| +376 | Andorra | | +48 | Poland ([area codes](#poland)) |
+| | | | +49 | Germany ([area codes](#germany)) |
 
 **Zone 5 — Central & South America**
 
-| Code | Country                   |   | Code | Country                              |
-|:-----|:--------------------------|:-:|:-----|:-------------------------------------|
-| +500 | Falkland Islands          |   | +56  | Chile                                |
-| +501 | Belize                    |   | +57  | Colombia                             |
-| +502 | Guatemala                 |   | +58  | Venezuela                            |
-| +503 | El Salvador               |   | +590 | Guadeloupe, St Barthélemy, St Martin |
-| +504 | Honduras                  |   | +591 | Bolivia                              |
-| +505 | Nicaragua                 |   | +592 | Guyana                               |
-| +506 | Costa Rica                |   | +593 | Ecuador                              |
-| +507 | Panama                    |   | +594 | French Guiana                        |
-| +508 | Saint Pierre and Miquelon |   | +595 | Paraguay                             |
-| +509 | Haiti                     |   | +596 | Martinique                           |
-| +51  | Peru                      |   | +597 | Suriname                             |
-| +52  | Mexico                    |   | +598 | Uruguay                              |
-| +53  | Cuba                      |   | +599 | Curaçao & Caribbean Netherlands      |
-| +54  | Argentina                 |   |      |                                      |
-| +55  | Brazil                    |   |      |                                      |
+| Code | Country | | Code | Country |
+|:-|:-|:-:|:-|:-|
+| +500 | Falkland Islands | | +56 | Chile ([area codes](#chile)) |
+| +501 | Belize | | +57 | Colombia |
+| +502 | Guatemala | | +58 | Venezuela |
+| +503 | El Salvador | | +590 | Guadeloupe, St Barthélemy, St Martin |
+| +504 | Honduras | | +591 | Bolivia |
+| +505 | Nicaragua | | +592 | Guyana |
+| +506 | Costa Rica | | +593 | Ecuador |
+| +507 | Panama ([area codes](#panama)) | | +594 | French Guiana |
+| +508 | Saint Pierre and Miquelon | | +595 | Paraguay |
+| +509 | Haiti | | +596 | Martinique |
+| +51 | Peru | | +597 | Suriname |
+| +52 | Mexico ([area codes](#mexico)) | | +598 | Uruguay |
+| +53 | Cuba | | +599 | Curaçao & Caribbean Netherlands |
+| +54 | Argentina ([area codes](#argentina)) | | | |
+| +55 | Brazil ([area codes](#brazil)) | | | |
 
 **Zone 6 — Southeast Asia & Oceania**
 
-| Code | Country          |   | Code | Country           |
-|:-----|:-----------------|:-:|:-----|:------------------|
-| +60  | Malaysia         |   | +681 | Wallis and Futuna |
-| +61  | Australia        |   | +682 | Cook Islands      |
-| +62  | Indonesia        |   | +683 | Niue              |
-| +63  | Philippines      |   | +685 | Samoa             |
-| +64  | New Zealand      |   | +686 | Kiribati          |
-| +65  | Singapore        |   | +687 | New Caledonia     |
-| +66  | Thailand         |   | +688 | Tuvalu            |
-| +670 | Timor-Leste      |   | +689 | French Polynesia  |
-| +672 | Norfolk Island   |   | +690 | Tokelau           |
-| +673 | Brunei           |   | +691 | Micronesia        |
-| +674 | Nauru            |   | +692 | Marshall Islands  |
-| +675 | Papua New Guinea |   |      |                   |
-| +676 | Tonga            |   |      |                   |
-| +677 | Solomon Islands  |   |      |                   |
-| +678 | Vanuatu          |   |      |                   |
-| +679 | Fiji             |   |      |                   |
-| +680 | Palau            |   |      |                   |
+| Code | Country | | Code | Country |
+|:-|:-|:-:|:-|:-|
+| +60 | Malaysia | | +681 | Wallis and Futuna |
+| +61 | Australia ([area codes](#australia)) | | +682 | Cook Islands |
+| +62 | Indonesia | | +683 | Niue |
+| +63 | Philippines | | +685 | Samoa |
+| +64 | New Zealand ([area codes](#new-zealand)) | | +686 | Kiribati |
+| +65 | Singapore | | +687 | New Caledonia |
+| +66 | Thailand ([area codes](#thailand)) | | +688 | Tuvalu |
+| +670 | Timor-Leste | | +689 | French Polynesia |
+| +672 | Norfolk Island | | +690 | Tokelau |
+| +673 | Brunei | | +691 | Micronesia |
+| +674 | Nauru | | +692 | Marshall Islands |
+| +675 | Papua New Guinea | | | |
+| +676 | Tonga | | | |
+| +677 | Solomon Islands | | | |
+| +678 | Vanuatu | | | |
+| +679 | Fiji | | | |
+| +680 | Palau | | | |
 
 **Zone 7 — Russia & Kazakhstan**
 
-| Code | Country    |
-|:-----|:-----------|
-| +7   | Russia     |
-| +7   | Kazakhstan |
+| Code | Country |
+|:-|:-|
+| +7 | Russia ([area codes](#russia)) |
+| +7 | Kazakhstan |
 
 **Zone 8 — East Asia & special services**
 
-| Code | Country     |
-|:-----|:------------|
-| +81  | Japan       |
-| +82  | South Korea |
-| +84  | Vietnam     |
+| Code | Country |
+|:-|:-|
+| +81 | Japan ([area codes](#japan)) |
+| +82 | South Korea ([area codes](#south-korea)) |
+| +84 | Vietnam ([area codes](#vietnam)) |
 | +850 | North Korea |
-| +852 | Hong Kong   |
-| +853 | Macau       |
-| +855 | Cambodia    |
-| +856 | Laos        |
-| +86  | China       |
-| +880 | Bangladesh  |
-| +886 | Taiwan      |
+| +852 | Hong Kong |
+| +853 | Macau |
+| +855 | Cambodia |
+| +856 | Laos |
+| +86 | China |
+| +880 | Bangladesh |
+| +886 | Taiwan ([area codes](#taiwan)) |
 
 **Zone 9 — West, Central & South Asia**
 
-| Code | Country      |   | Code | Country              |
-|:-----|:-------------|:-:|:-----|:---------------------|
-| +90  | Turkey       |   | +971 | United Arab Emirates |
-| +91  | India        |   | +972 | Israel               |
-| +92  | Pakistan     |   | +973 | Bahrain              |
-| +93  | Afghanistan  |   | +974 | Qatar                |
-| +94  | Sri Lanka    |   | +975 | Bhutan               |
-| +95  | Myanmar      |   | +976 | Mongolia             |
-| +960 | Maldives     |   | +977 | Nepal                |
-| +961 | Lebanon      |   | +98  | Iran                 |
-| +962 | Jordan       |   | +992 | Tajikistan           |
-| +963 | Syria        |   | +993 | Turkmenistan         |
-| +964 | Iraq         |   | +994 | Azerbaijan           |
-| +965 | Kuwait       |   | +995 | Georgia              |
-| +966 | Saudi Arabia |   | +996 | Kyrgyzstan           |
-| +967 | Yemen        |   | +998 | Uzbekistan           |
-| +968 | Oman         |   |      |                      |
-| +970 | Palestine    |   |      |                      |
+| Code | Country | | Code | Country |
+|:-|:-|:-:|:-|:-|
+| +90 | Turkey ([area codes](#turkey)) | | +971 | United Arab Emirates |
+| +91 | India | | +972 | Israel |
+| +92 | Pakistan | | +973 | Bahrain |
+| +93 | Afghanistan | | +974 | Qatar |
+| +94 | Sri Lanka ([area codes](#sri-lanka)) | | +975 | Bhutan |
+| +95 | Myanmar | | +976 | Mongolia |
+| +960 | Maldives | | +977 | Nepal |
+| +961 | Lebanon | | +98 | Iran |
+| +962 | Jordan | | +992 | Tajikistan |
+| +963 | Syria | | +993 | Turkmenistan |
+| +964 | Iraq | | +994 | Azerbaijan |
+| +965 | Kuwait | | +995 | Georgia |
+| +966 | Saudi Arabia | | +996 | Kyrgyzstan |
+| +967 | Yemen | | +998 | Uzbekistan |
+| +968 | Oman | | | |
+| +970 | Palestine | | | |
 
 {{% /details %}}
 
-## Area code
+## Area codes
+
+### Argentina
+
+Area code map coming soon — see [Plonk It: Argentina](https://www.plonkit.net/argentina) for now.
+
+### Australia
+
+Area code map coming soon — see [Plonk It: Australia](https://www.plonkit.net/australia) for now.
+
+### Austria
+
+Area code map coming soon — see [Plonk It: Austria](https://www.plonkit.net/austria) for now.
+
+### Brazil
+
+- São Paulo: 11
+- Rio: 21
+- Brasília: 61
+- Fortaleza: 85
+
+{{% details "Full" %}}
+
+<img src="https://images.squarespace-cdn.com/content/v1/60f6054f4e76b03092956de8/930c8141-7d6e-4397-a56c-f58b902e85c1/Brasil_-_Códigos_de_área_DDD.png"/>
+
+{{% /details %}}
+
+### Bulgaria
+
+Area code map coming soon — see [Plonk It: Bulgaria](https://www.plonkit.net/bulgaria) for now.
+
+### Chile
+
+Area code map coming soon — see [Plonk It: Chile](https://www.plonkit.net/chile) for now.
+
+### Croatia
+
+Area code map coming soon — see [Plonk It: Croatia](https://www.plonkit.net/croatia) for now.
+
+### Czech Republic
+
+Area code map coming soon — see [Plonk It: Czechia](https://www.plonkit.net/czechia) for now.
+
+### France
+
+Area code map coming soon — see [Plonk It: France](https://www.plonkit.net/france) for now.
+
+### Germany
+
+Area code map coming soon — see [Plonk It: Germany](https://www.plonkit.net/germany) for now.
+
+### Ghana
+
+Area code map coming soon — see [Plonk It: Ghana](https://www.plonkit.net/ghana) for now.
+
+### Greece
+
+Area code map coming soon — see [Plonk It: Greece](https://www.plonkit.net/greece) for now.
+
+### Italy
+
+Area code map coming soon — see [Plonk It: Italy](https://www.plonkit.net/italy) for now.
 
 ### Japan
 
@@ -204,15 +265,78 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 {{% /details %}}
 
-### Brazil
+### Mexico
 
-- São Paulo: 11
-- Rio: 21
-- Brasília: 61
-- Fortaleza: 85
+Area code map coming soon — see [Plonk It: Mexico](https://www.plonkit.net/mexico) for now.
 
-{{% details "Full" %}}
+### Namibia
 
-<img src="https://images.squarespace-cdn.com/content/v1/60f6054f4e76b03092956de8/930c8141-7d6e-4397-a56c-f58b902e85c1/Brasil_-_Códigos_de_área_DDD.png"/>
+Area code map coming soon — see [Plonk It: Namibia](https://www.plonkit.net/namibia) for now.
 
-{{% /details %}}
+### Netherlands
+
+Area code map coming soon — see [Plonk It: Netherlands](https://www.plonkit.net/netherlands) for now.
+
+### New Zealand
+
+Area code map coming soon — see [Plonk It: New Zealand](https://www.plonkit.net/new-zealand) for now.
+
+### Panama
+
+Area code map coming soon — see [Plonk It: Panama](https://www.plonkit.net/panama) for now.
+
+### Poland
+
+Area code map coming soon — see [Plonk It: Poland](https://www.plonkit.net/poland) for now.
+
+### Portugal
+
+Area code map coming soon — see [Plonk It: Portugal](https://www.plonkit.net/portugal) for now.
+
+### Russia
+
+Area code map coming soon — see [Plonk It: Russia](https://www.plonkit.net/russia) for now.
+
+### Slovakia
+
+Area code map coming soon — see [Plonk It: Slovakia](https://www.plonkit.net/slovakia) for now.
+
+### South Africa
+
+Area code map coming soon — see [Plonk It: South Africa](https://www.plonkit.net/south-africa) for now.
+
+### South Korea
+
+Area code map coming soon — see [Plonk It: South Korea](https://www.plonkit.net/south-korea) for now.
+
+### Spain
+
+Area code map coming soon — see [Plonk It: Spain](https://www.plonkit.net/spain) for now.
+
+### Sri Lanka
+
+Area code map coming soon — see [Plonk It: Sri Lanka](https://www.plonkit.net/sri-lanka) for now.
+
+### Sweden
+
+Area code map coming soon — see [Plonk It: Sweden](https://www.plonkit.net/sweden) for now.
+
+### Taiwan
+
+Area code map coming soon — see [Plonk It: Taiwan](https://www.plonkit.net/taiwan) for now.
+
+### Thailand
+
+Area code map coming soon — see [Plonk It: Thailand](https://www.plonkit.net/thailand) for now.
+
+### Turkey
+
+Area code map coming soon — see [Plonk It: Turkey](https://www.plonkit.net/turkey) for now.
+
+### United States
+
+Area code map coming soon — see [Plonk It: United States](https://www.plonkit.net/united-states) for now.
+
+### Vietnam
+
+Area code map coming soon — see [Plonk It: Vietnam](https://www.plonkit.net/vietnam) for now.

--- a/content/docs/telephone.md
+++ b/content/docs/telephone.md
@@ -4,6 +4,19 @@ weight: 100
 
 # Telephone
 
+Every country is reachable by an international **country calling code** (`+XX`).  
+This world map is the quickest first anchor:  
+First identify the code, then narrow down further by area code (see below; limited to countries that use one)
+
+<figure>
+  <img src="https://upload.wikimedia.org/wikipedia/commons/5/55/Country_calling_codes_map.svg" alt="World map of international country calling codes" loading="lazy" style="width: 100%;" />
+  <figcaption>
+    Country calling codes worldwide. Map by
+    <a href="https://commons.wikimedia.org/wiki/File:Country_calling_codes_map.svg" target="_blank" rel="noopener">Maximilian Dörrbecker (Chumwa)</a>,
+    <a href="https://creativecommons.org/licenses/by-sa/2.0/" target="_blank" rel="noopener">CC BY-SA 2.0</a>.
+  </figcaption>
+</figure>
+
 ## Area code
 
 ### Japan

--- a/content/docs/telephone.md
+++ b/content/docs/telephone.md
@@ -191,9 +191,20 @@ Prefer a **lookup table**? The list below covers every country's calling code, g
 
 ## Area codes
 
+{{% details "Credits" %}}
+
+> Most of these maps' credits go to [Plonk It](https://www.plonkit.net/guide) — at the very least for collecting them;  
+> A few of the following maps are from elsewhere: [Argentina](https://learnablemeta.com/maps/6824efee8646292930db9807) from [Learnable Meta](https://learnablemeta.com/), [Austria](https://commons.wikimedia.org/wiki/File:Telefonvorwahlbereiche-Oesterreich.svg) and [Ghana](https://commons.wikimedia.org/wiki/File:Ghana_regional_phone_codes.jpg) from [Wikimedia Commons](https://commons.wikimedia.org).
+
+{{% /details %}}
+
 ### Argentina
 
-Area code map coming soon — see [Plonk It: Argentina](https://www.plonkit.net/argentina) for now.
+{{% details "Full" %}}
+
+<img src="https://learnablemeta.com/images/1398/1749471291095-UdG.avif"/>
+
+{{% /details %}}
 
 ### Australia
 
@@ -205,7 +216,11 @@ Area code map coming soon — see [Plonk It: Argentina](https://www.plonkit.net/
 
 ### Austria
 
-Area code map coming soon — see [Plonk It: Austria](https://www.plonkit.net/austria) for now.
+{{% details "Full" %}}
+
+<img src="https://upload.wikimedia.org/wikipedia/commons/7/7b/Telefonvorwahlbereiche-Oesterreich.svg"/>
+
+{{% /details %}}
 
 ### Brazil
 
@@ -270,7 +285,11 @@ Area code map coming soon — see [Plonk It: Austria](https://www.plonkit.net/au
 
 ### Ghana
 
-Area code map coming soon — see [Plonk It: Ghana](https://www.plonkit.net/ghana) for now.
+{{% details "Full" %}}
+
+<img src="https://upload.wikimedia.org/wikipedia/commons/9/92/Ghana_regional_phone_codes.jpg"/>
+
+{{% /details %}}
 
 ### Greece
 

--- a/content/docs/telephone.md
+++ b/content/docs/telephone.md
@@ -197,7 +197,11 @@ Area code map coming soon — see [Plonk It: Argentina](https://www.plonkit.net/
 
 ### Australia
 
-Area code map coming soon — see [Plonk It: Australia](https://www.plonkit.net/australia) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/australia/Phone_codes.png"/>
+
+{{% /details %}}
 
 ### Austria
 
@@ -218,27 +222,51 @@ Area code map coming soon — see [Plonk It: Austria](https://www.plonkit.net/au
 
 ### Bulgaria
 
-Area code map coming soon — see [Plonk It: Bulgaria](https://www.plonkit.net/bulgaria) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/bulgaria/bg_areacodes.png"/>
+
+{{% /details %}}
 
 ### Chile
 
-Area code map coming soon — see [Plonk It: Chile](https://www.plonkit.net/chile) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/chile/Chile_Area_Codes.png"/>
+
+{{% /details %}}
 
 ### Croatia
 
-Area code map coming soon — see [Plonk It: Croatia](https://www.plonkit.net/croatia) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/croatia/hr_areacodes_copy.png"/>
+
+{{% /details %}}
 
 ### Czech Republic
 
-Area code map coming soon — see [Plonk It: Czechia](https://www.plonkit.net/czechia) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/czechia/cz_areacodes.png"/>
+
+{{% /details %}}
 
 ### France
 
-Area code map coming soon — see [Plonk It: France](https://www.plonkit.net/france) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/france/2_areacodes.png"/>
+
+{{% /details %}}
 
 ### Germany
 
-Area code map coming soon — see [Plonk It: Germany](https://www.plonkit.net/germany) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/germany/800px-Karte_Telefonvorwahlen_Deutschland.png"/>
+
+{{% /details %}}
 
 ### Ghana
 
@@ -246,11 +274,19 @@ Area code map coming soon — see [Plonk It: Ghana](https://www.plonkit.net/ghan
 
 ### Greece
 
-Area code map coming soon — see [Plonk It: Greece](https://www.plonkit.net/greece) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/greece/gr_areacodes_darkmode.png"/>
+
+{{% /details %}}
 
 ### Italy
 
-Area code map coming soon — see [Plonk It: Italy](https://www.plonkit.net/italy) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/italy/it_phonecodes.png"/>
+
+{{% /details %}}
 
 ### Japan
 
@@ -267,76 +303,152 @@ Area code map coming soon — see [Plonk It: Italy](https://www.plonkit.net/ital
 
 ### Mexico
 
-Area code map coming soon — see [Plonk It: Mexico](https://www.plonkit.net/mexico) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/mexico/mx_areacodes_nobg.png"/>
+
+{{% /details %}}
 
 ### Namibia
 
-Area code map coming soon — see [Plonk It: Namibia](https://www.plonkit.net/namibia) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/namibia/12.png"/>
+
+{{% /details %}}
 
 ### Netherlands
 
-Area code map coming soon — see [Plonk It: Netherlands](https://www.plonkit.net/netherlands) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/netherlands/Area_codes_of_the_Netherlands.png"/>
+
+{{% /details %}}
 
 ### New Zealand
 
-Area code map coming soon — see [Plonk It: New Zealand](https://www.plonkit.net/new-zealand) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/new-zealand/nz_area_codes_new.png"/>
+
+{{% /details %}}
 
 ### Panama
 
-Area code map coming soon — see [Plonk It: Panama](https://www.plonkit.net/panama) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/panama/13.png"/>
+
+{{% /details %}}
 
 ### Poland
 
-Area code map coming soon — see [Plonk It: Poland](https://www.plonkit.net/poland) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/poland/Poland-area-codes.png"/>
+
+{{% /details %}}
 
 ### Portugal
 
-Area code map coming soon — see [Plonk It: Portugal](https://www.plonkit.net/portugal) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/portugal/2areacodes_darkmode.webp"/>
+
+{{% /details %}}
 
 ### Russia
 
-Area code map coming soon — see [Plonk It: Russia](https://www.plonkit.net/russia) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/russia/areacodes.png"/>
+
+{{% /details %}}
 
 ### Slovakia
 
-Area code map coming soon — see [Plonk It: Slovakia](https://www.plonkit.net/slovakia) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/slovakia/sk_areacodes.png"/>
+
+{{% /details %}}
 
 ### South Africa
 
-Area code map coming soon — see [Plonk It: South Africa](https://www.plonkit.net/south-africa) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/south-africa/ZA_Phone_Code_Map.png"/>
+
+{{% /details %}}
 
 ### South Korea
 
-Area code map coming soon — see [Plonk It: South Korea](https://www.plonkit.net/south-korea) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/south-korea/kr_phonecodes.png"/>
+
+{{% /details %}}
 
 ### Spain
 
-Area code map coming soon — see [Plonk It: Spain](https://www.plonkit.net/spain) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/spain/Spain-telephone-codes__281_29_darkmode.png"/>
+
+{{% /details %}}
 
 ### Sri Lanka
 
-Area code map coming soon — see [Plonk It: Sri Lanka](https://www.plonkit.net/sri-lanka) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/sri-lanka/Sri_area_codes.png"/>
+
+{{% /details %}}
 
 ### Sweden
 
-Area code map coming soon — see [Plonk It: Sweden](https://www.plonkit.net/sweden) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/sweden/Phone_numbers.png"/>
+
+{{% /details %}}
 
 ### Taiwan
 
-Area code map coming soon — see [Plonk It: Taiwan](https://www.plonkit.net/taiwan) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/taiwan/a-more-detailed-taiwan-area-code-map.webp"/>
+
+{{% /details %}}
 
 ### Thailand
 
-Area code map coming soon — see [Plonk It: Thailand](https://www.plonkit.net/thailand) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/thailand/Indicatifs_Thailande.png"/>
+
+{{% /details %}}
 
 ### Turkey
 
-Area code map coming soon — see [Plonk It: Turkey](https://www.plonkit.net/turkey) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/turkey/tr_areacodes_nobg.png"/>
+
+{{% /details %}}
 
 ### United States
 
-Area code map coming soon — see [Plonk It: United States](https://www.plonkit.net/united-states) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/united-states/US_area_codes_map.jfif"/>
+
+{{% /details %}}
 
 ### Vietnam
 
-Area code map coming soon — see [Plonk It: Vietnam](https://www.plonkit.net/vietnam) for now.
+{{% details "Full" %}}
+
+<img src="https://www.plonkit.net/images/vietnam/vnareacodes_map.jpg"/>
+
+{{% /details %}}


### PR DESCRIPTION
Overhauls the **Telephone** page so a phone number can be traced to a region at a glance — starting from the country calling code, then narrowing down by area code.

## What changed

- **World map on top.** The page now opens with the Wikimedia "Country calling codes map" as the primary visual anchor (CC BY-SA 2.0, attributed).
- **Full country-code list.** The old hand-picked country-code table is replaced by a collapsible list of *every* country's calling code, grouped by ITU-T E.164 zone.
- **Area-code sections for 33 countries.** Each country with a GeoGuessr-relevant regional area-code system (the Learnable Meta "Area Codes" set plus the USA) gets a section with its area-code map in a collapsible, in the existing Japan/Brazil style. Every such country is linked from the country-code list via `([area codes](#anchor))`.
- **Map sources.** Most maps were collected by [Plonk It](https://www.plonkit.net/guide); a few come from Wikimedia Commons (Austria, Ghana) and Learnable Meta (Argentina). Credited in a collapsible note under *Area codes*.

## Notes

- All maps are hotlinked; every image URL was verified reachable (`200`), and all internal anchor links resolve.
- The US map is a `.jfif` served as `application/octet-stream`; it renders via browser content-sniffing (no `nosniff` header).