### PR TITLE
Test(hotlinks): Add an external link-reachability checker

### DIFF
--- a/content/docs/sign/traffic-sign/_index.md
+++ b/content/docs/sign/traffic-sign/_index.md
@@ -158,7 +158,7 @@ Finland, Sweden, Iceland, Poland, North Macedonia, Greece
 
 #### Australia
 
-{{<figure src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7c/Australia_road_sign_R1-2.svg/272px-Australia_road_sign_R1-2.svg.png"
+{{<figure src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7c/Australia_road_sign_R1-2.svg/250px-Australia_road_sign_R1-2.svg.png"
   caption="black text" class="img-sm" >}}
 
 <--->

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "Tooling for the Geoguessr Note site (the site itself is built with Hugo).",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "test": "node scripts/check-links.mjs",
     "check-links": "node scripts/check-links.mjs"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "geoguessr-note",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Tooling for the Geoguessr Note site (the site itself is built with Hugo).",
+  "type": "module",
+  "scripts": {
+    "test": "node scripts/check-links.mjs",
+    "check-links": "node scripts/check-links.mjs"
+  }
+}

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -18,6 +18,12 @@ import { dirname, join, resolve, relative } from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
 
+// Hosts to skip entirely (never fetched): known-good but they block automated
+// checks, so they'd only ever show up as noise. Add a RegExp per host to silence.
+const IGNORE = [
+  /\binaturalist\.org/, // 403s the bot UA; pages load fine in a browser
+];
+
 const SKIP_DIRS = new Set(['.git', 'node_modules', 'themes', 'public', 'resources']);
 const CONCURRENCY = 6;
 const TIMEOUT_MS = 20000;
@@ -27,9 +33,6 @@ const UA =
 
 const WARN_STATUS = new Set([403, 405, 429, 503]); // reachable but blocked/throttled
 const RETRY_STATUS = new Set([429, 503]);
-
-// Add a RegExp here to skip a host that blocks automated checks but is known-good.
-const IGNORE = [];
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -48,6 +48,7 @@ const SKIP_DIRS = new Set(['.git', 'node_modules', 'themes', 'public', 'resource
 const CONCURRENCY = 6;
 const TIMEOUT_MS = 20000;
 const MAX_RETRIES = 4; // for throttling / transient errors
+const MAX_BACKOFF_MS = 30000; // cap even a large Retry-After so a run can't hang
 const UA =
   'Mozilla/5.0 (compatible; geoguessr-note-linkcheck/1.0; +https://github.com/dingyiyi0226/geoguessr-note)';
 
@@ -138,7 +139,8 @@ async function reachable(url) {
 
     const transient = error != null || RETRY_STATUS.has(status);
     if (transient && attempt < MAX_RETRIES) {
-      const backoff = retryAfter != null ? retryAfter * 1000 : Math.min(8000, 500 * 2 ** attempt);
+      const base = retryAfter != null ? retryAfter * 1000 : Math.min(8000, 500 * 2 ** attempt);
+      const backoff = Math.min(base, MAX_BACKOFF_MS);
       await sleep(backoff + Math.random() * 300);
       continue;
     }

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -103,19 +103,19 @@ async function requestStatus(url, method) {
   return { status: res.status, retryAfter: parseRetryAfter(res.headers.get('retry-after')) };
 }
 
-function isBlockedHost(url) {
-  let host;
-  try {
-    host = new URL(url).hostname;
-  } catch {
-    return false;
-  }
+function isBlockedHost(host) {
   return BLOCKED_HOST.some((re) => re.test(host));
 }
 
 // Returns { class: 'ok' | 'warn' | 'fail', status, error? }
 async function reachable(url) {
-  if (isBlockedHost(url)) return { class: 'fail', status: 0, error: 'blocked host (SSRF guard)' };
+  let host;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return { class: 'fail', status: 0, error: 'invalid URL' };
+  }
+  if (isBlockedHost(host)) return { class: 'fail', status: 0, error: 'blocked host (SSRF guard)' };
   for (let attempt = 0; ; attempt++) {
     let status = 0;
     let retryAfter = null;

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -38,8 +38,10 @@ const BLOCKED_HOST = [
   /^192\.168\./,
   /^169\.254\./,
   /^172\.(1[6-9]|2\d|3[01])\./,
-  /^\[?::1\]?$/,
-  /^\[?f[cd]/i,
+  // IPv6 literals only (URL.hostname brackets them), so real hostnames like fdroid.org aren't caught
+  /^\[::1\]$/, // loopback
+  /^\[f[cd]/i, // ULA fc00::/7
+  /^\[fe[89ab]/i, // link-local fe80::/10
 ];
 
 const SKIP_DIRS = new Set(['.git', 'node_modules', 'themes', 'public', 'resources']);

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -127,7 +127,7 @@ async function runPool(items, worker, size) {
   return results;
 }
 
-const files = await collectMarkdown(ROOT);
+const files = [join(ROOT, 'README.md'), ...(await collectMarkdown(join(ROOT, 'content')))];
 const usage = new Map(); // url -> Set(relative file paths)
 for (const file of files) {
   const text = await readFile(file, 'utf8');

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -107,7 +107,7 @@ async function reachable(url) {
 
     const transient = error != null || RETRY_STATUS.has(status);
     if (transient && attempt < MAX_RETRIES) {
-      const backoff = retryAfter ? retryAfter * 1000 : Math.min(8000, 500 * 2 ** attempt);
+      const backoff = retryAfter != null ? retryAfter * 1000 : Math.min(8000, 500 * 2 ** attempt);
       await sleep(backoff + Math.random() * 300);
       continue;
     }

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -24,6 +24,20 @@ const IGNORE = [
   /\binaturalist\.org/, // 403s the bot UA; pages load fine in a browser
 ];
 
+// Private/loopback/link-local hosts are never fetched: a public docs link should
+// never point there, and fetching one on untrusted input would be an SSRF vector.
+// Not airtight — a public hostname resolving to a private IP still gets through.
+const BLOCKED_HOST = [
+  /^localhost$/i,
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^\[?::1\]?$/,
+  /^\[?f[cd]/i,
+];
+
 const SKIP_DIRS = new Set(['.git', 'node_modules', 'themes', 'public', 'resources']);
 const CONCURRENCY = 6;
 const TIMEOUT_MS = 20000;
@@ -83,8 +97,19 @@ async function requestStatus(url, method) {
   return { status: res.status, retryAfter: parseRetryAfter(res.headers.get('retry-after')) };
 }
 
+function isBlockedHost(url) {
+  let host;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return false;
+  }
+  return BLOCKED_HOST.some((re) => re.test(host));
+}
+
 // Returns { class: 'ok' | 'warn' | 'fail', status, error? }
 async function reachable(url) {
+  if (isBlockedHost(url)) return { class: 'fail', status: 0, error: 'blocked host (SSRF guard)' };
   for (let attempt = 0; ; attempt++) {
     let status = 0;
     let retryAfter = null;

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// Checks every external http(s) link in the project's Markdown (README + content/)
+// for reachability, and exits non-zero if any link is genuinely broken.
+//
+//   node scripts/check-links.mjs
+//
+// No dependencies — uses the global fetch from Node 18+.
+//
+// Result classes:
+//   OK    2xx / 3xx
+//   WARN  403 / 405 / 429 / 503 — reachable but blocked or throttled; not counted as failure
+//   FAIL  404 / 410 / other 4xx / 5xx / timeout / network error — exits 1
+
+import { readdir, readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve, relative } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const SKIP_DIRS = new Set(['.git', 'node_modules', 'themes', 'public', 'resources']);
+const CONCURRENCY = 6;
+const TIMEOUT_MS = 20000;
+const MAX_RETRIES = 4; // for throttling / transient errors
+const UA =
+  'Mozilla/5.0 (compatible; geoguessr-note-linkcheck/1.0; +https://github.com/dingyiyi0226/geoguessr-note)';
+
+const WARN_STATUS = new Set([403, 405, 429, 503]); // reachable but blocked/throttled
+const RETRY_STATUS = new Set([429, 503]);
+
+// Add a RegExp here to skip a host that blocks automated checks but is known-good.
+const IGNORE = [];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function collectMarkdown(dir, out = []) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      await collectMarkdown(join(dir, entry.name), out);
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+      out.push(join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+const URL_PATTERNS = [
+  /\]\((https?:\/\/[^)\s]+)\)/g, // [text](url) and ![alt](url)
+  /(?:href|src)\s*=\s*["'](https?:\/\/[^"']+)["']/g, // <a href="…"> / <img src="…">
+];
+
+function extractUrls(text) {
+  const urls = new Set();
+  for (const pattern of URL_PATTERNS) {
+    for (const match of text.matchAll(pattern)) urls.add(match[1]);
+  }
+  return urls;
+}
+
+async function requestStatus(url, method) {
+  const res = await fetch(url, {
+    method,
+    redirect: 'follow',
+    headers: { 'User-Agent': UA },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  try {
+    await res.body?.cancel(); // don't download the body (some maps are several MB)
+  } catch {}
+  const retryAfter = Number(res.headers.get('retry-after'));
+  return { status: res.status, retryAfter: Number.isFinite(retryAfter) ? retryAfter : null };
+}
+
+// Returns { class: 'ok' | 'warn' | 'fail', status, error? }
+async function reachable(url) {
+  for (let attempt = 0; ; attempt++) {
+    let status = 0;
+    let retryAfter = null;
+    let error = null;
+    try {
+      // Prefer HEAD; fall back to GET (many CDNs reject or mishandle HEAD).
+      let r = await requestStatus(url, 'HEAD');
+      if (!(r.status >= 200 && r.status < 400)) r = await requestStatus(url, 'GET');
+      status = r.status;
+      retryAfter = r.retryAfter;
+    } catch (err) {
+      error = err?.message || String(err);
+    }
+
+    if (!error && status >= 200 && status < 400) return { class: 'ok', status };
+
+    const transient = error != null || RETRY_STATUS.has(status);
+    if (transient && attempt < MAX_RETRIES) {
+      const backoff = retryAfter ? retryAfter * 1000 : Math.min(8000, 500 * 2 ** attempt);
+      await sleep(backoff + Math.random() * 300);
+      continue;
+    }
+
+    if (!error && WARN_STATUS.has(status)) return { class: 'warn', status };
+    return { class: 'fail', status, error };
+  }
+}
+
+async function runPool(items, worker, size) {
+  const results = new Array(items.length);
+  let next = 0;
+  const runner = async () => {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await worker(items[i]);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(size, items.length) }, runner));
+  return results;
+}
+
+const files = await collectMarkdown(ROOT);
+const usage = new Map(); // url -> Set(relative file paths)
+for (const file of files) {
+  const text = await readFile(file, 'utf8');
+  const rel = relative(ROOT, file);
+  for (const url of extractUrls(text)) {
+    if (IGNORE.some((re) => re.test(url))) continue;
+    if (!usage.has(url)) usage.set(url, new Set());
+    usage.get(url).add(rel);
+  }
+}
+
+const urls = [...usage.keys()].sort();
+if (urls.length === 0) {
+  console.log('No external links found.');
+  process.exit(0);
+}
+
+console.log(`Checking ${urls.length} external link(s) across ${files.length} Markdown file(s)…\n`);
+
+const marks = { ok: '✓', warn: '⚠', fail: '✗' };
+const results = await runPool(
+  urls,
+  async (url) => {
+    const r = await reachable(url);
+    console.log(`${marks[r.class]} ${String(r.status || 'ERR').padEnd(3)} ${url}`);
+    return { url, ...r };
+  },
+  CONCURRENCY,
+);
+
+const warns = results.filter((r) => r.class === 'warn');
+const fails = results.filter((r) => r.class === 'fail');
+
+if (warns.length) {
+  console.log(`\n${warns.length} warning(s) — reachable but blocked/throttled, not treated as failures:`);
+  for (const r of warns) console.log(`  ⚠ [${r.status}] ${r.url}`);
+}
+
+if (fails.length) {
+  console.log(`\n${fails.length} broken link(s):`);
+  for (const r of fails) {
+    console.log(`  ✗ [${r.status || r.error}] ${r.url}`);
+    console.log(`      in: ${[...usage.get(r.url)].join(', ')}`);
+  }
+}
+
+const ok = results.length - warns.length - fails.length;
+console.log(`\n${ok} OK, ${warns.length} warning(s), ${fails.length} broken — of ${results.length} link(s).`);
+process.exit(fails.length ? 1 : 0);

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -56,7 +56,7 @@ async function collectMarkdown(dir, out = []) {
 
 const URL_PATTERNS = [
   /\]\((https?:\/\/[^)\s]+)\)/g, // [text](url) and ![alt](url)
-  /(?:href|src)\s*=\s*["'](https?:\/\/[^"']+)["']/g, // <a href="…"> / <img src="…">
+  /[\w:.-]+\s*=\s*["'](https?:\/\/[^"']+)["']/g, // any attr="url": href, src, shortcode params (link=, …)
 ];
 
 function extractUrls(text) {

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -6,6 +6,10 @@
 //
 // No dependencies — uses the global fetch from Node 18+.
 //
+// Intended for local / trusted CI use only: it fetches every URL it finds, and
+// the BLOCKED_HOST guard is best-effort (see its note), so don't run it on
+// untrusted input without proper resolved-IP SSRF hardening.
+//
 // Result classes:
 //   OK    2xx / 3xx
 //   WARN  403 / 405 / 429 / 503 — reachable but blocked or throttled; not counted as failure

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -33,6 +33,15 @@ const IGNORE = [];
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+function parseRetryAfter(value) {
+  if (!value) return null;
+  const secs = Number(value);
+  if (Number.isFinite(secs)) return secs;
+  // Retry-After may also be an HTTP-date rather than delta-seconds.
+  const date = Date.parse(value);
+  return Number.isNaN(date) ? null : Math.max(0, (date - Date.now()) / 1000);
+}
+
 async function collectMarkdown(dir, out = []) {
   for (const entry of await readdir(dir, { withFileTypes: true })) {
     if (entry.isDirectory()) {
@@ -68,8 +77,7 @@ async function requestStatus(url, method) {
   try {
     await res.body?.cancel(); // don't download the body (some maps are several MB)
   } catch {}
-  const retryAfter = Number(res.headers.get('retry-after'));
-  return { status: res.status, retryAfter: Number.isFinite(retryAfter) ? retryAfter : null };
+  return { status: res.status, retryAfter: parseRetryAfter(res.headers.get('retry-after')) };
 }
 
 // Returns { class: 'ok' | 'warn' | 'fail', status, error? }

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -79,9 +79,13 @@ async function reachable(url) {
     let retryAfter = null;
     let error = null;
     try {
-      // Prefer HEAD; fall back to GET (many CDNs reject or mishandle HEAD).
+      // Prefer HEAD; fall back to GET (many CDNs reject or mishandle HEAD), but
+      // not for retryable statuses — a GET would just double the load
+      // on a host that's already throttling us.
       let r = await requestStatus(url, 'HEAD');
-      if (!(r.status >= 200 && r.status < 400)) r = await requestStatus(url, 'GET');
+      if (!(r.status >= 200 && r.status < 400) && !RETRY_STATUS.has(r.status)) {
+        r = await requestStatus(url, 'GET');
+      }
       status = r.status;
       retryAfter = r.retryAfter;
     } catch (err) {

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -72,7 +72,7 @@ async function collectMarkdown(dir, out = []) {
 }
 
 const URL_PATTERNS = [
-  /\]\((https?:\/\/[^)\s]+)\)/g, // [text](url) and ![alt](url)
+  /\]\(\s*(https?:\/\/[^)\s]+)\s*\)/g, // [text](url) and ![alt](url), tolerating spaces inside ()
   /[\w:.-]+\s*=\s*["'](https?:\/\/[^"']+)["']/g, // any attr="url": href, src, shortcode params (link=, …)
 ];
 

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -53,7 +53,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 function parseRetryAfter(value) {
   if (!value) return null;
   const secs = Number(value);
-  if (Number.isFinite(secs)) return secs;
+  if (Number.isFinite(secs)) return Math.max(0, secs);
   // Retry-After may also be an HTTP-date rather than delta-seconds.
   const date = Date.parse(value);
   return Number.isNaN(date) ? null : Math.max(0, (date - Date.now()) / 1000);


### PR DESCRIPTION
Adds `scripts/check-links.mjs` — a zero-dependency Node script that checks every external `http(s)` link in the project's Markdown (`README.md` + `content/`) for reachability.

```sh
npm test        # alias — same as: node scripts/check-links.mjs
```

A minimal `package.json` (no dependencies) provides the `npm test` / `npm run check-links` alias; the project otherwise stays Hugo-only.

**Behaviour**

- No dependencies (uses the global `fetch` from Node 18+); cross-platform.
- Sends a browser User-Agent, follows redirects, tries `HEAD` then falls back to `GET`.
- Retries throttled hosts with backoff (honouring `Retry-After`) so Wikimedia rate-limiting doesn't cause false alarms.
- Classifies each link as **OK** (2xx/3xx), **WARN** (403/405/429/503 — reachable but blocked/throttled) or **FAIL** (404/410/other 4xx/5xx/timeout), and exits non-zero if anything is broken — so it can also run in CI.

Running it over the current content came back clean except for one genuinely dead link, which this PR also fixes: a Wikimedia road-sign thumbnail requested at a `272px` width that the thumbnailer rejects (`400`); switched to `250px`.

---

**Follow-up for the maintainer (README):** depends on #9. Once [#9](https://github.com/dingyiyi0226/geoguessr-note/pull/9) is merged, add this under its *Local Development* section:

> ### Check links
>
> Verify that every external link in the docs is still reachable:
>
> ```sh
> npm test
> ```