### PR TITLE
style(tables): sticky table header rows

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -51,6 +51,25 @@
     background: color-mix(in srgb, var(--gray-100), var(--gray-200));
   }
 
+  // let tables scroll with the page so header rows can stick to the viewport
+  // (overrides the theme's display:block; overflow:auto, which traps sticky)
+  table {
+    display: table;
+    overflow: visible;
+  }
+  // opt-out for very wide tables that need their own horizontal scroll
+  table.table-scroll {
+    display: block;
+    overflow: auto;
+  }
+
+  // keep non-empty header rows in view while scrolling long tables
+  table thead:has(th:not(:empty)) th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
   // reset styles settings for details under blockquote
   blockquote details summary:first-child {
     margin-top: -$padding-16;

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -54,7 +54,7 @@
   // long tables scroll inside their own box (theme already sets display:block; overflow:auto)
   // so the header row can stick to the top while scrolling the rows
   table {
-    max-height: 95vh;
+    max-height: 90vh;
   }
   table thead:has(th:not(:empty)) th {
     position: sticky;

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -57,6 +57,7 @@
   table {
     display: block;
     overflow: auto;
+    max-height: 90vh; // fallback for browsers without dvh
     max-height: 90dvh;
   }
   table thead:has(th:not(:empty)) th {

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -51,19 +51,11 @@
     background: color-mix(in srgb, var(--gray-100), var(--gray-200));
   }
 
-  // let tables scroll with the page so header rows can stick to the viewport
-  // (overrides the theme's display:block; overflow:auto, which traps sticky)
+  // long tables scroll inside their own box (theme already sets display:block; overflow:auto)
+  // so the header row can stick to the top while scrolling the rows
   table {
-    display: table;
-    overflow: visible;
+    max-height: 95vh;
   }
-  // opt-out for very wide tables that need their own horizontal scroll
-  table.table-scroll {
-    display: block;
-    overflow: auto;
-  }
-
-  // keep non-empty header rows in view while scrolling long tables
   table thead:has(th:not(:empty)) th {
     position: sticky;
     top: 0;

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -51,10 +51,13 @@
     background: color-mix(in srgb, var(--gray-100), var(--gray-200));
   }
 
-  // long tables scroll inside their own box (theme already sets display:block; overflow:auto)
-  // so the header row can stick to the top while scrolling the rows
+  // Long tables get their own scroll box so the header row can stick while
+  // the rows scroll; the sticky needs block+overflow to form that box, so
+  // set them here rather than relying on the theme. dvh caps to the visible mobile viewport.
   table {
-    max-height: 90vh;
+    display: block;
+    overflow: auto;
+    max-height: 90dvh;
   }
   table thead:has(th:not(:empty)) th {
     position: sticky;


### PR DESCRIPTION
On long tables the column headers scroll out of view, so you lose track of which column is which. This keeps the header row pinned to the top while you scroll the table's rows.

## What changed

`assets/_custom.scss`:

- `table { display: block; overflow: auto; max-height: 90dvh }` so a table taller than the viewport scrolls vertically inside its own box, with the scroll-container properties set explicitly here so the sticky header can't silently break if the theme changes.
- `table thead:has(th:not(:empty)) th { position: sticky; top: 0; z-index: 1 }` so header cells stay at the top of that box while scrolling.

## Notes

- Header cells already have an opaque background from the theme, so scrolled rows don't show through.
- The `:has(th:not(:empty))` guard means tables with an empty header row (most of the existing content tables) are unaffected — no empty grey bar.
- The header sticks to the top of the table's own scroll box (not the viewport), because keeping the table as its own scroll container is also what keeps wide-table borders correct.
- The `90dvh` threshold means the vertical scroll only appears for tables taller than the screen; shorter tables show in full with no scrollbar, and `dvh` caps to the visible mobile viewport instead of overshooting behind the URL bar.