### PR TITLE
fix(config): capitalize "GitHub" in the menu label

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -6,7 +6,7 @@ enableGitInfo = true
 
 [menus]
 [[menus.after]]
-  name = "Github"
+  name = "GitHub"
   url = "https://github.com/dingyiyi0226/geoguessr-note"
 [params]
   BookTheme = 'light'


### PR DESCRIPTION
Fixes the sidebar menu label "Github" to the standard "GitHub"