### PR TITLE
style(tables): sticky first table column

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -65,6 +65,19 @@
     top: 0;
     z-index: 1;
   }
+  // Opt-in sticky first column: pins the row-label column when a wide table
+  // scrolls sideways; opaque band so scrolled cells don't bleed through.
+  .sticky-col th:first-child,
+  .sticky-col td:first-child {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    background: color-mix(in srgb, var(--gray-100), var(--gray-200));
+  }
+  // corner is both sticky row + column, so it must win on both axes
+  .sticky-col thead th:first-child {
+    z-index: 2;
+  }
 
   // reset styles settings for details under blockquote
   blockquote details summary:first-child {

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -51,6 +51,25 @@
     background: color-mix(in srgb, var(--gray-100), var(--gray-200));
   }
 
+  // let tables scroll with the page so header rows can stick to the viewport
+  // (overrides the theme's display:block; overflow:auto, which traps sticky)
+  table {
+    display: table;
+    overflow: visible;
+  }
+  // opt-out for very wide tables that need their own horizontal scroll
+  table.table-scroll {
+    display: block;
+    overflow: auto;
+  }
+
+  // keep non-empty header rows in view while scrolling long tables
+  table thead:has(th:not(:empty)) th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
   // reset styles settings for details under blockquote
   blockquote details summary:first-child {
     margin-top: -$padding-16;

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -54,7 +54,7 @@
   // long tables scroll inside their own box (theme already sets display:block; overflow:auto)
   // so the header row can stick to the top while scrolling the rows
   table {
-    max-height: 95vh;
+    max-height: 90vh;
   }
   table thead:has(th:not(:empty)) th {
     position: sticky;

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -57,6 +57,7 @@
   table {
     display: block;
     overflow: auto;
+    max-height: 90vh; // fallback for browsers without dvh
     max-height: 90dvh;
   }
   table thead:has(th:not(:empty)) th {

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -51,19 +51,11 @@
     background: color-mix(in srgb, var(--gray-100), var(--gray-200));
   }
 
-  // let tables scroll with the page so header rows can stick to the viewport
-  // (overrides the theme's display:block; overflow:auto, which traps sticky)
+  // long tables scroll inside their own box (theme already sets display:block; overflow:auto)
+  // so the header row can stick to the top while scrolling the rows
   table {
-    display: table;
-    overflow: visible;
+    max-height: 95vh;
   }
-  // opt-out for very wide tables that need their own horizontal scroll
-  table.table-scroll {
-    display: block;
-    overflow: auto;
-  }
-
-  // keep non-empty header rows in view while scrolling long tables
   table thead:has(th:not(:empty)) th {
     position: sticky;
     top: 0;

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -51,10 +51,13 @@
     background: color-mix(in srgb, var(--gray-100), var(--gray-200));
   }
 
-  // long tables scroll inside their own box (theme already sets display:block; overflow:auto)
-  // so the header row can stick to the top while scrolling the rows
+  // Long tables get their own scroll box so the header row can stick while
+  // the rows scroll; the sticky needs block+overflow to form that box, so
+  // set them here rather than relying on the theme. dvh caps to the visible mobile viewport.
   table {
-    max-height: 90vh;
+    display: block;
+    overflow: auto;
+    max-height: 90dvh;
   }
   table thead:has(th:not(:empty)) th {
     position: sticky;

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -74,9 +74,12 @@
     z-index: 1;
     background: color-mix(in srgb, var(--gray-100), var(--gray-200));
   }
-  // corner is both sticky row + column, so it must win on both axes
-  .sticky-col thead th:first-child {
+  // header row sits above the sticky column, and the corner above both
+  .sticky-col thead th {
     z-index: 2;
+  }
+  .sticky-col thead th:first-child {
+    z-index: 3;
   }
 
   // reset styles settings for details under blockquote


### PR DESCRIPTION
The horizontal counterpart to the sticky header row (PR #13): on wide tables that scroll sideways, this keeps the first column pinned so the row label stays visible.

## What changed

`assets/_custom.scss`:

- `.sticky-col th:first-child, .sticky-col td:first-child { position: sticky; left: 0; z-index: 1; background: … }` pins the first column with an opaque band.
- `.sticky-col thead th { z-index: 2 }` and `.sticky-col thead th:first-child { z-index: 3 }` so the header row stays above the sticky column and the corner cell above both.

## Notes

- Opt-in per table via the `.sticky-col` block attribute — no existing table changes behaviour unless it adds the class.
- The opaque band is required (unlike the header row, body cells are transparent by default, so without it scrolled cells would show through the pinned column).
- The selector matches whether `.sticky-col` sits on the table itself or on a wrapper, so both markup styles work.
- Tested against the two wide tables in `content/docs/car-meta/_index.md` (gen-4 "Car" column, gen-3 year matrix); those test applications were reverted before commit.